### PR TITLE
Fix: Add missing ringstwo property to itemsByType initialization

### DIFF
--- a/main.js
+++ b/main.js
@@ -146,6 +146,7 @@ function populateItemDropdowns() {
     belts: [],
     boots: [],
     ringsone: [],
+    ringstwo: [],
     amulets: []
   };
 


### PR DESCRIPTION
This fixes the 'Cannot read properties of undefined' error when populating dropdowns. The ringstwo array was being referenced at line 171 but was never initialized in the itemsByType object.