### PR TITLE
Fix skill container error and add mercenary item support

### DIFF
--- a/character.js
+++ b/character.js
@@ -225,7 +225,7 @@ getDirectLifeManaFromItems() {
   const bonuses = { life: 0, mana: 0 };
   const currentLevel = parseInt(document.getElementById('lvlValue')?.value) || 1;
 
-  // FIXED: Complete list of all equipment sections
+  // FIXED: Complete list of all equipment sections (player + mercenary)
   const equipmentSections = [
     { dropdown: 'weapons-dropdown', section: 'weapon' },
     { dropdown: 'helms-dropdown', section: 'helm' },
@@ -236,7 +236,15 @@ getDirectLifeManaFromItems() {
     { dropdown: 'boots-dropdown', section: 'boots' },
     { dropdown: 'ringsone-dropdown', section: 'ringone' },
     { dropdown: 'ringstwo-dropdown', section: 'ringtwo' },
-    { dropdown: 'amulets-dropdown', section: 'amulet' }
+    { dropdown: 'amulets-dropdown', section: 'amulet' },
+    // Mercenary equipment
+    { dropdown: 'mercweapons-dropdown', section: 'mercweapon' },
+    { dropdown: 'merchelms-dropdown', section: 'merchelm' },
+    { dropdown: 'mercarmors-dropdown', section: 'mercarmor' },
+    { dropdown: 'mercoffs-dropdown', section: 'mercoff' },
+    { dropdown: 'mercgloves-dropdown', section: 'mercgloves' },
+    { dropdown: 'mercbelts-dropdown', section: 'mercbelts' },
+    { dropdown: 'mercboots-dropdown', section: 'mercboots' }
   ];
 
   //('🔍 Checking equipment for life/mana bonuses:');
@@ -295,8 +303,8 @@ getDirectLifeManaFromItems() {
     }
   });
 
-  // Get life/mana from sockets
-  const socketSections = ['weapon', 'helm', 'armor', 'shield', 'gloves', 'belts', 'boots', 'ringone', 'ringtwo', 'amulet'];
+  // Get life/mana from sockets (player + mercenary)
+  const socketSections = ['weapon', 'helm', 'armor', 'shield', 'gloves', 'belts', 'boots', 'ringone', 'ringtwo', 'amulet', 'mercweapon', 'merchelm', 'mercarmor', 'mercoff', 'mercgloves', 'mercbelts', 'mercboots'];
   
   socketSections.forEach(section => {
     const sockets = document.querySelectorAll(`.socket-container[data-section="${section}"] .socket-slot.filled`);
@@ -373,7 +381,15 @@ getDirectLifeManaFromItems() {
       { dropdown: 'boots-dropdown', section: 'boots' },
       { dropdown: 'ringsone-dropdown', section: 'ring' },
       { dropdown: 'ringstwo-dropdown', section: 'ring' },
-      { dropdown: 'amulets-dropdown', section: 'amulet' }
+      { dropdown: 'amulets-dropdown', section: 'amulet' },
+      // Mercenary equipment
+      { dropdown: 'mercweapons-dropdown', section: 'mercweapon' },
+      { dropdown: 'merchelms-dropdown', section: 'merchelm' },
+      { dropdown: 'mercarmors-dropdown', section: 'mercarmor' },
+      { dropdown: 'mercoffs-dropdown', section: 'mercoff' },
+      { dropdown: 'mercgloves-dropdown', section: 'mercgloves' },
+      { dropdown: 'mercbelts-dropdown', section: 'mercbelts' },
+      { dropdown: 'mercboots-dropdown', section: 'mercboots' }
     ];
 
     equipmentSections.forEach(({ dropdown, section }) => {
@@ -403,7 +419,7 @@ getDirectLifeManaFromItems() {
     const bonuses = { str: 0, dex: 0, vit: 0, enr: 0 };
     const currentLevel = parseInt(document.getElementById('lvlValue')?.value) || 1;
 
-    const sections = ['weapon', 'helm', 'armor', 'shield', 'gloves', 'belts', 'boots'];
+    const sections = ['weapon', 'helm', 'armor', 'shield', 'gloves', 'belts', 'boots', 'mercweapon', 'merchelm', 'mercarmor', 'mercoff', 'mercgloves', 'mercbelts', 'mercboots'];
     
     sections.forEach(section => {
       const sockets = document.querySelectorAll(`.socket-container[data-section="${section}"] .socket-slot.filled`);

--- a/corrupt.js
+++ b/corrupt.js
@@ -171,7 +171,7 @@ const CORRUPTIONS = {
 // Section mapping for dropdowns to item types
 const SECTION_MAP = {
   'helms-dropdown': 'helm',
-  'armors-dropdown': 'armor', 
+  'armors-dropdown': 'armor',
   'weapons-dropdown': 'weapon',
   'offs-dropdown': 'shield',
   'gloves-dropdown': 'gloves',
@@ -179,7 +179,15 @@ const SECTION_MAP = {
   'boots-dropdown': 'boots',
   'ringsone-dropdown': 'ring',
   'ringstwo-dropdown': 'ring',
-  'amulets-dropdown': 'amulet'
+  'amulets-dropdown': 'amulet',
+  // Mercenary equipment
+  'merchelms-dropdown': 'merchelm',
+  'mercarmors-dropdown': 'mercarmor',
+  'mercweapons-dropdown': 'mercweapon',
+  'mercoffs-dropdown': 'mercoff',
+  'mercgloves-dropdown': 'mercgloves',
+  'mercbelts-dropdown': 'mercbelts',
+  'mercboots-dropdown': 'mercboots'
 };
 
 // Global variables

--- a/skills.js
+++ b/skills.js
@@ -715,10 +715,7 @@ getDeadlyStrikeChance() {
       }
     }
 
-    // Recheck overall skill points if any value was adjusted
-    if (anyChanged) {
-      this.handleSkillInput({value: 0});  // Trigger the validation logic
-    }
+    // No need to call handleSkillInput - updatePointsDisplay is already called in setupEvents
   }
 
   updatePointsDisplay() {

--- a/socket.js
+++ b/socket.js
@@ -33,7 +33,15 @@
         'boots-dropdown': { info: 'boot-info', section: 'boots' },
         'ringsone-dropdown': { info: 'ringsone-info', section: 'ringone' },
         'ringstwo-dropdown': { info: 'ringstwo-info', section: 'ringtwo' },
-        'amulets-dropdown': { info: 'amulet-info', section: 'amulet' }
+        'amulets-dropdown': { info: 'amulet-info', section: 'amulet' },
+        // Mercenary equipment
+        'mercweapons-dropdown': { info: 'merc-weapon-info', section: 'mercweapon' },
+        'merchelms-dropdown': { info: 'merc-helm-info', section: 'merchelm' },
+        'mercarmors-dropdown': { info: 'merc-armor-info', section: 'mercarmor' },
+        'mercoffs-dropdown': { info: 'merc-off-info', section: 'mercoff' },
+        'mercgloves-dropdown': { info: 'merc-glove-info', section: 'mercgloves' },
+        'mercbelts-dropdown': { info: 'merc-belt-info', section: 'mercbelts' },
+        'mercboots-dropdown': { info: 'merc-boot-info', section: 'mercboots' }
       };
       
       // Fast stats tracking


### PR DESCRIPTION
Skill Container Fix:
- Remove incorrect handleSkillInput() call in validateAllSkillInputs()
- Fix TypeError where plain object was passed instead of DOM element

Mercenary Equipment Support (8 locations fixed):
- Add mercenary entries to socket.js equipmentMap (7 dropdowns)
- Add mercenary sections to character.js getDirectLifeManaFromItems() (item bonuses + sockets)
- Add mercenary sections to character.js getAllItemBonuses() (stat bonuses)
- Add mercenary sections to character.js getSocketBonuses() (socket stat bonuses)
- Add mercenary mappings to corrupt.js SECTION_MAP (corruption system support)

This enables:
- Mercenary items now contribute stat bonuses (str/dex/vit/enr)
- Mercenary item sockets now contribute bonuses
- Mercenary items now provide life/mana bonuses
- Mercenary items work with the corruption system