### PR TITLE
Fix: Assign updateItemInfo to window to fix runeword.js wrapper

### DIFF
--- a/main.js
+++ b/main.js
@@ -397,7 +397,7 @@ function attachStatInputListeners() {
 /**
  * Update item info display when dropdown selection changes
  */
-function updateItemInfo(event) {
+window.updateItemInfo = function updateItemInfo(event) {
   const dropdown = event.target;
   const selectedItemName = dropdown.value;
 


### PR DESCRIPTION
- runeword.js wraps window.updateItemInfo to preserve runeword displays
- Our function declaration wasn't properly assigned to window
- Now explicitly assign to window.updateItemInfo so wrapper works correctly