### PR TITLE
Fix: Call window.updateItemInfo to use wrapped version

### DIFF
--- a/main.js
+++ b/main.js
@@ -472,10 +472,10 @@ function setupDropdownHandlers() {
         console.log(`🔔🔔🔔 CHANGE EVENT FIRED for ${dropdownId}!`);
         console.log('About to call updateItemInfo...');
         console.log('Event object:', event);
-        console.log('updateItemInfo function:', updateItemInfo);
+        console.log('updateItemInfo function:', window.updateItemInfo);
         try {
           console.log('INSIDE TRY BLOCK');
-          updateItemInfo(event);
+          window.updateItemInfo(event);
           console.log('AFTER updateItemInfo call');
         } catch (error) {
           console.error('💥💥💥 ERROR in updateItemInfo:', error);


### PR DESCRIPTION
- The function was defined as 'function updateItemInfo' creating a local reference
- Event listeners were calling updateItemInfo() directly, bypassing runeword.js wrapper
- This prevented the actual function from executing for Biggin's Bonnet and other items
- Changed to call window.updateItemInfo() to use the properly wrapped version
- Now dynamic item descriptions (like Biggin's Bonnet) will populate correctly