### PR TITLE
Fix: Remove socket.js override of window.updateItemInfo

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -3778,24 +3778,15 @@ const statsArray = [
     // Hide modal when clicking outside
   // === AUTO-INITIALIZATION ===
   document.addEventListener('DOMContentLoaded', function() {
-
-    
     // Create global instance
     window.unifiedSocketSystem = new UnifiedSocketSystem();
-    
-    // Also create legacy function names for compatibility
-    window.updateItemInfo = () => {
-      if (window.unifiedSocketSystem) {
-        window.unifiedSocketSystem.updateAll();
-      }
-    };
-    
+
+    // Legacy function for compatibility
     window.validateAllItems = () => {
       if (window.unifiedSocketSystem) {
         window.unifiedSocketSystem.updateAll();
       }
     };
-
   });
 
   // === FALLBACK FOR IMMEDIATE AVAILABILITY ===


### PR DESCRIPTION
- socket.js was completely replacing window.updateItemInfo
- This destroyed the real function from main.js that displays item info
- Result: ALL items showed blank descriptions (not just Biggin's Bonnet)
- main.js already calls unifiedSocketSystem.updateAll() at the end
- Removed the destructive override, keeping only validateAllItems for compatibility
- Now the real updateItemInfo runs: shows descriptions AND updates sockets