### PR TITLE
Fix: Socket system now preserves dynamic item descriptions

### DIFF
--- a/main.js
+++ b/main.js
@@ -440,6 +440,14 @@ window.updateItemInfo = function updateItemInfo(event) {
     console.log('✅ innerHTML SET! Div now contains:', infoDiv.innerHTML);
     console.log('📊 Div visibility:', window.getComputedStyle(infoDiv).display, 'opacity:', window.getComputedStyle(infoDiv).opacity);
 
+    // Check if content persists after a delay
+    setTimeout(() => {
+      console.log('⏰ 100ms later, div contains:', infoDiv.innerHTML);
+      if (!infoDiv.innerHTML || infoDiv.innerHTML.trim() === '') {
+        console.error('🚨 CONTENT WAS CLEARED! Something removed it!');
+      }
+    }, 100);
+
     // Attach event listeners to any stat input boxes
     attachStatInputListeners();
   } else {

--- a/socket.js
+++ b/socket.js
@@ -2040,9 +2040,10 @@ this.selectedJewelSuffix3MaxValue = null;
     const currentLevel = parseInt(document.getElementById('lvlValue')?.value) || 1;
     const actualRequiredLevel = this.calculateActualRequiredLevel(section, dropdown.value);
     const meetsRequirement = currentLevel >= actualRequiredLevel;
-    
+
     // Parse base item stats
-    let baseDescription = item.description || '';
+    // Use existing innerHTML if no static description (for dynamically generated items like Biggin's Bonnet)
+    let baseDescription = item.description || infoDiv.innerHTML || '';
     const baseStats = this.parseStatsToMap(baseDescription);
     
     // Get socket stats and merge with base stats


### PR DESCRIPTION
- socket.js was overwriting innerHTML with empty string for dynamic items
- Biggin's Bonnet has no item.description, generates HTML dynamically
- main.js sets innerHTML with generated description
- Then socket.js overwrote it with '' because item.description was undefined
- Now socket.js uses existing innerHTML as fallback for dynamic items
- Also added debug timeout to track if content persists