### PR TITLE
Feature: Add property mappings for all Diablo 2 stats

### DIFF
--- a/main.js
+++ b/main.js
@@ -317,6 +317,17 @@ function generateItemDescription(itemName, item, dropdownId) {
     todef: (val) => `+${val} Defense`,
     tolife: (val) => `+${val} to Life`,
     tomana: (val) => `+${val} to Mana`,
+    ias: (val, prop) => formatVariableStat('+', val, '% Increased Attack Speed', prop, itemName, 'ias', dropdownId),
+    fhr: (val, prop) => formatVariableStat('+', val, '% Faster Hit Recovery', prop, itemName, 'fhr', dropdownId),
+    frw: (val, prop) => formatVariableStat('+', val, '% Faster Run/Walk', prop, itemName, 'frw', dropdownId),
+    block: (val, prop) => formatVariableStat('', val, '% Increased Chance of Blocking', prop, itemName, 'block', dropdownId),
+    edef: (val, prop) => formatVariableStat('+', val, '% Enhanced Defense', prop, itemName, 'edef', dropdownId),
+    repl: (val, prop) => formatVariableStat('Replenish Life +', val, '', prop, itemName, 'repl', dropdownId),
+    allsk: (val, prop) => formatVariableStat('+', val, ' to All Skills', prop, itemName, 'allsk', dropdownId),
+    str: (val, prop) => formatVariableStat('+', val, ' to Strength', prop, itemName, 'str', dropdownId),
+    dex: (val, prop) => formatVariableStat('+', val, ' to Dexterity', prop, itemName, 'dex', dropdownId),
+    vit: (val, prop) => formatVariableStat('+', val, ' to Vitality', prop, itemName, 'vit', dropdownId),
+    enr: (val, prop) => formatVariableStat('+', val, ' to Energy', prop, itemName, 'enr', dropdownId),
   };
 
   // Build description from properties


### PR DESCRIPTION
- Added ias (Increased Attack Speed) with variable support
- Added fhr (Faster Hit Recovery) with variable support
- Added frw (Faster Run/Walk) with variable support
- Added block (Chance of Blocking) with variable support
- Added edef (Enhanced Defense) with variable support
- Added repl (Replenish Life) with variable support
- Added allsk (All Skills) with variable support
- Added str, dex, vit, enr (stats) with variable support
- Now Twitchthroe, Peasant Crown, etc. can show dynamic descriptions
- Any property with {min, max, current} will show input box