### PR TITLE
Fix: Socket system handles dynamic items without breaking

### DIFF
--- a/main.js
+++ b/main.js
@@ -282,7 +282,7 @@ function getPropertyValue(prop) {
 /**
  * Generate item description HTML with input boxes for variable stats
  */
-function generateItemDescription(itemName, item, dropdownId) {
+window.generateItemDescription = function generateItemDescription(itemName, item, dropdownId) {
   console.log('generateItemDescription called for:', itemName, 'item:', item, 'dropdownId:', dropdownId);
 
   if (!item) return '';

--- a/socket.js
+++ b/socket.js
@@ -2060,9 +2060,21 @@ this.selectedJewelSuffix3MaxValue = null;
       return; // Don't touch innerHTML - preserve user's input values
     }
 
-    // Parse base item stats
-    // Use existing innerHTML if no static description (for dynamically generated items like Biggin's Bonnet)
-    let baseDescription = item.description || infoDiv.innerHTML || '';
+    // For dynamic items WITH sockets, regenerate the description using main.js function
+    // Do NOT try to parse innerHTML - it contains input boxes which breaks parsing!
+    let baseDescription;
+    if (!item.description && sockets.length > 0 && typeof window.generateItemDescription === 'function') {
+      // Call main.js to regenerate clean description
+      baseDescription = window.generateItemDescription(dropdown.value, item, dropdownId);
+      // Strip out any input elements for parsing
+      const tempDiv = document.createElement('div');
+      tempDiv.innerHTML = baseDescription;
+      tempDiv.querySelectorAll('.stat-input').forEach(input => input.remove());
+      baseDescription = tempDiv.innerHTML;
+    } else {
+      baseDescription = item.description || '';
+    }
+
     const baseStats = this.parseStatsToMap(baseDescription);
 
     // Build socket items array


### PR DESCRIPTION
- Socket system was parsing innerHTML with input boxes causing infinite loops
- Numbers were exploding (700, 81100, 529529529) due to broken HTML parsing
- Now regenerates clean description for dynamic items WITH sockets
- Strips input elements before parsing to get clean stat values
- Made generateItemDescription global for socket system access
- Dynamic items without sockets still preserve input values