### PR TITLE
Fix: Socket stats now persist on level changes + prevent item miscate…

### DIFF
--- a/character.js
+++ b/character.js
@@ -596,7 +596,7 @@ getDirectLifeManaFromItems() {
   handleLevelChange() {
     const lvlInput = document.getElementById('lvlValue');
     let level = parseInt(lvlInput.value) || 1;
-    
+
     if (level > 99) {
       level = 99;
       lvlInput.value = 99;
@@ -604,13 +604,18 @@ getDirectLifeManaFromItems() {
       level = 1;
       lvlInput.value = 1;
     }
-    
+
     this.level = level;
     this.currentLevel = level;
-    
+
     this.validateStats();
     this.updateStatPointsDisplay();
     this.updateTotalStats();
+
+    // Update socket system to refresh item displays with merged stats
+    if (window.unifiedSocketSystem && typeof window.unifiedSocketSystem.updateAll === 'function') {
+      window.unifiedSocketSystem.updateAll();
+    }
   }
 
   handleClassChange() {

--- a/main.js
+++ b/main.js
@@ -126,12 +126,9 @@ function detectItemType(itemName, item) {
   if (item.description) {
     const desc = item.description.toLowerCase();
 
-    // Weapons
-    if (desc.includes('sword') || desc.includes('axe') || desc.includes('mace') ||
-        desc.includes('hammer') || desc.includes('spear') || desc.includes('bow') ||
-        desc.includes('staff') || desc.includes('dagger') || desc.includes('wand') ||
-        desc.includes('claw') || desc.includes('orb') || desc.includes('javelin') ||
-        desc.includes('polearm') || desc.includes('scepter') || desc.includes('scythe')) {
+    // Weapons - use word boundary regex to avoid false matches (e.g., "absorb" contains "orb")
+    const weaponPattern = /\b(sword|axe|mace|hammer|spear|bow|staff|dagger|wand|claw|orb|javelin|polearm|scepter|scythe)\b/;
+    if (weaponPattern.test(desc)) {
       return 'weapon';
     }
 


### PR DESCRIPTION
…gorization

Two critical fixes:

1. Socket stats persisting on level change
   - Added updateAll() call to handleLevelChange() in character.js
   - Previously, changing level would clear socket stat displays
   - Now properly refreshes all item displays with merged socket stats

2. Item categorization accuracy
   - Fixed weapon detection using word boundaries in main.js
   - Prevents "absorb" from matching "orb" weapon type
   - Fixes Blackhorn's Face (helm) and Raven Frost (ring) appearing in weapons dropdown