### PR TITLE
Fix: Weapon socket stats now persist when changing character stats

### DIFF
--- a/itemUpgrade.js
+++ b/itemUpgrade.js
@@ -4559,6 +4559,11 @@ function updateWeaponTooltip(currentItemData, baseType, isTwoHanded) {
   if (socketStats) weaponInfo.appendChild(socketStats);
   if (corruptedMod) weaponInfo.appendChild(corruptedMod);
   if (corruptedText) weaponInfo.appendChild(corruptedText);
+
+  // Update socket system to regenerate merged stats for dynamic items
+  if (window.unifiedSocketSystem && typeof window.unifiedSocketSystem.updateAll === 'function') {
+    window.unifiedSocketSystem.updateAll();
+  }
 }
 
 function updateWeaponDescription(itemData, isTwoHanded) {


### PR DESCRIPTION
The issue was that itemUpgrade.js had event listeners on str/dex/vit/enr inputs that called updateWeaponDamageDisplay() -> updateWeaponTooltip(), which directly set weapon-info innerHTML, destroying the socket system's merged stats.

Fix: Added updateAll() call at the end of updateWeaponTooltip() to regenerate the proper merged description with socket stats after the damage update.

This ensures socket stats remain visible when changing any character stat.