### PR TITLE
Fix: Update inventory position in correct CSS file

### DIFF
--- a/styles-patch.css
+++ b/styles-patch.css
@@ -459,7 +459,7 @@ body {
 .inventorycontainer {
   display: grid;
   position: absolute;
-  left: 33%;
+  left: 60vw;
   top: 23%;
   grid-template-columns: repeat(10, 40px);
   grid-gap: 1px;


### PR DESCRIPTION
Changed left: 33% to left: 60vw in styles-patch.css (the actual loaded CSS file). Previous changes to styles.css had no effect since only styles-patch.css is loaded in index.html.