### PR TITLE
Fix: Inventory position now uses 60vw in JavaScript

### DIFF
--- a/inventory.js
+++ b/inventory.js
@@ -55,7 +55,7 @@ class CharmInventory {
     container.style.cssText = `
       position: absolute;
       margin-top: -120px;
-      left: 335px;
+      left: 60vw;
       display: grid;
       padding: 0;
       background-color: rgb(0, 0, 0);


### PR DESCRIPTION
Changed inventory.js:58 from left: 335px to left: 60vw. The JavaScript was setting inline styles via container.style.cssText, which overrides any CSS file settings. This was the actual issue preventing the CSS changes from taking effect.