### PR TITLE
Feature: Auto-apply socket corruption for 3-socket armors

### DIFF
--- a/corrupt.js
+++ b/corrupt.js
@@ -16,7 +16,10 @@ const CORRUPTIONS = {
   armor: [
     { mod: "+[40-60] to Life", type: "numeric", range: [40, 60] },
     { mod: "+10% Faster Hit Recovery", type: "fixed" },
-    { mod: "+1 to All Skills", type: "fixed" }
+    { mod: "+1 to All Skills", type: "fixed" },
+    { mod: "1 Socket", type: "socket", sockets: 1 },
+    { mod: "2 Sockets", type: "socket", sockets: 2 },
+    { mod: "3 Sockets", type: "socket", sockets: 3 }
   ],
   weapon: [
     { mod: "+[40-80]% Enhanced Damage", type: "numeric", range: [40, 80] },
@@ -927,6 +930,43 @@ function closeCorruptionModal() {
   document.getElementById('corruptionModal').style.display = 'none';
   currentCorruptionSlot = null;
 }
+
+// Programmatically apply socket corruption (called from socket system)
+window.applySocketCorruption = function(dropdownId, socketCount) {
+  const dropdown = document.getElementById(dropdownId);
+  if (!dropdown) {
+    console.error('Dropdown not found:', dropdownId);
+    return;
+  }
+
+  const itemName = dropdown.value;
+  if (!itemName || !itemList[itemName]) {
+    console.error('Item not found:', itemName);
+    return;
+  }
+
+  // Store original description if not already stored
+  if (!window.originalItemDescriptions[itemName]) {
+    window.originalItemDescriptions[itemName] = itemList[itemName].description;
+  }
+
+  // Create corruption text based on socket count
+  const corruptionText = socketCount === 1 ? '1 Socket' : `${socketCount} Sockets`;
+
+  // Store corruption info
+  window.itemCorruptions[dropdownId] = {
+    text: corruptionText,
+    type: 'socket_corruption',
+    itemName: itemName,
+    socketCount: socketCount
+  };
+
+  console.log(`Auto-applied ${corruptionText} corruption to ${itemName}`);
+
+  // Don't modify description for socket corruptions - sockets are visual
+  // Just mark the item as corrupted in the UI
+  triggerItemUpdate(dropdownId);
+};
 
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/socket.js
+++ b/socket.js
@@ -1406,8 +1406,13 @@
 
       // Lookup socket limit by base type
       if (baseType) {
-        const limit = this.baseTypeSocketLimits[baseType];
+        let limit = this.baseTypeSocketLimits[baseType];
         if (limit !== undefined) {
+          // For armor section, cap at 3 sockets for unique/set items
+          // (3+ sockets only possible through corruption)
+          if (section === 'armor' && limit > 3) {
+            limit = 3;
+          }
           console.log(`Socket limit for ${itemName}: ${limit}`);
           return limit;
         }
@@ -1484,6 +1489,15 @@
 
       const newSocketCount = existingSockets + 1;
       socketGrid.className = `socket-grid sockets-${newSocketCount}`;
+
+      // Auto-apply socket corruption when adding 3rd socket to armor
+      if (section === 'armor' && newSocketCount === 3) {
+        const dropdownId = this.getSectionDropdownId(section);
+        if (dropdownId && typeof window.applySocketCorruption === 'function') {
+          console.log('Auto-applying 3 Sockets corruption to armor');
+          window.applySocketCorruption(dropdownId, 3);
+        }
+      }
 
     }
 


### PR DESCRIPTION
In D2, unique/set armors can only get 3 sockets through corruption, not through normal means (Larzuk quest gives max 2). This implements proper socket corruption mechanics for armors.

Changes to corrupt.js:
- Added socket corruption options to armor: "1 Socket", "2 Sockets", "3 Sockets"
- Created window.applySocketCorruption() function to programmatically apply socket corruptions without opening the modal
- Stores corruption info with type 'socket_corruption' to track corrupted items

Changes to socket.js:
- Modified addSocket() to auto-apply "3 Sockets" corruption when adding 3rd socket to armor section
- Updated getMaxSocketsForSection() to cap armor at max 3 sockets, even if base type allows 4 (since 4 sockets impossible for unique/set armors)

Now when users add a 3rd socket to armor, the system automatically applies the appropriate corruption, reflecting actual game mechanics.