### PR TITLE
Fix: Socket corruption now creates actual socket slots

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -1422,46 +1422,6 @@
       return 1;
     }
 
-    // Adjust socket count when switching items
-    adjustSocketsForNewItem(section) {
-      console.log(`⚙️ adjustSocketsForNewItem called for section: ${section}`);
-
-      const container = document.querySelector(`.socket-container[data-section="${section}"]`);
-      if (!container) {
-        console.log(`⚠️ No container found for section: ${section}`);
-        return;
-      }
-
-      const socketGrid = container.querySelector('.socket-grid');
-      if (!socketGrid) {
-        console.log(`⚠️ No socket grid found in container`);
-        return;
-      }
-
-      const maxSockets = this.getMaxSocketsForSection(section);
-      const currentSockets = socketGrid.querySelectorAll('.socket-slot');
-      const currentCount = currentSockets.length;
-
-      console.log(`🔄 Adjusting sockets for ${section}: current=${currentCount}, max=${maxSockets}`);
-
-      if (currentCount > maxSockets) {
-        // Remove excess sockets
-        console.log(`✂️ Removing ${currentCount - maxSockets} excess sockets...`);
-        for (let i = currentCount - 1; i >= maxSockets; i--) {
-          const socket = currentSockets[i];
-          console.log(`  Removing socket ${i}`);
-          socket.remove();
-        }
-        socketGrid.className = `socket-grid sockets-${maxSockets}`;
-        console.log(`✅ Removed sockets, now have ${maxSockets}`);
-      } else if (currentCount < maxSockets) {
-        // Don't auto-add sockets, user must use + button
-        console.log(`📊 Can add ${maxSockets - currentCount} more sockets`);
-      } else {
-        console.log(`✅ Socket count matches max (${currentCount})`);
-      }
-    }
-
     addSocket(section) {
       const container = document.querySelector(`.socket-container[data-section="${section}"]`);
       if (!container) {
@@ -1533,6 +1493,43 @@
         // Update stats after removing sockets
         this.updateAll();
       }
+    }
+
+    // Set socket count to exact number (for corruption system)
+    setSocketCount(section, targetCount) {
+      const container = document.querySelector(`.socket-container[data-section="${section}"]`);
+      if (!container) {
+        console.error(`No container found for section: ${section}`);
+        return;
+      }
+
+      const socketGrid = container.querySelector('.socket-grid');
+      if (!socketGrid) {
+        console.error(`No socket grid found for section: ${section}`);
+        return;
+      }
+
+      const currentCount = socketGrid.children.length;
+      console.log(`Setting socket count for ${section}: ${currentCount} → ${targetCount}`);
+
+      // Remove all existing sockets first
+      while (socketGrid.firstChild) {
+        socketGrid.removeChild(socketGrid.firstChild);
+      }
+
+      // Add the target number of sockets
+      for (let i = 0; i < targetCount; i++) {
+        const socket = document.createElement('div');
+        socket.className = 'socket-slot empty';
+        socket.dataset.index = i.toString();
+        socketGrid.appendChild(socket);
+      }
+
+      // Update grid class
+      socketGrid.className = `socket-grid sockets-${targetCount}`;
+
+      // Update stats
+      this.updateAll();
     }
 
     handleSocketClick(e) {


### PR DESCRIPTION
Previously, socket corruptions ("Socketed (1/2/3)") only added text to the item description but didn't create the actual socket slots in the DOM. Now selecting a socket corruption from the modal properly creates the specified number of sockets.

Changes to corrupt.js:
- Updated armor socket corruptions to display as "Socketed (1)", "Socketed (2)", "Socketed (3)" instead of "1 Socket", "2 Sockets", "3 Sockets"
- Added special handling for socket-type corruptions in populateCorruptionList()
- Created applySocketCorruptionFromModal() function that:
  * Adds corruption text to item description with red styling
  * Calls setSocketCount() to create the actual socket slots
  * Stores corruption metadata for tracking
- Updated applySocketCorruption() to use "Socketed (X)" format and add description text with corruption styling

Changes to socket.js:
- Removed old adjustSocketsForNewItem() function with verbose debug logs
- Added setSocketCount(section, targetCount) method that:
  * Removes all existing sockets
  * Creates exactly the specified number of empty socket slots
  * Updates socket grid class and recalculates stats

Now when you select "Socketed (2)" from the corruption modal, it will:
1. Add "Socketed (2)" text in red to the item description
2. Create exactly 2 socket slots in the item
3. Mark the item as corrupted