### PR TITLE
Fix: Socket corruption now creates actual socket slots

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,10 +94,7 @@
               <button id="corruptWeapon">Corrupt</button>
               <div id="weapon-info" class="item-info"></div>
               <div class="socket-container" data-section="weapon">
-                <div class="socket-grid sockets-0">     
-                  <div class="socket-slot empty" data-index="0"></div>
-                  <div class="socket-slot empty" data-index="1"></div>
-                </div>
+                <div class="socket-grid sockets-0"></div>
                   <button class="add-socket-btn" onclick="addSocket('weapon')">+</button>
                 </div>
             </div>
@@ -112,10 +109,7 @@
               <button id="corruptHelm">Corrupt</button>
               <div id="helm-info" class="item-info"></div>
               <div class="socket-container" data-section="helm">
-                <div class="socket-grid sockets-0">
-  <div class="socket-slot empty" data-index="0"></div>
-  <div class="socket-slot empty" data-index="1"></div>
-  </div>
+                <div class="socket-grid sockets-0"></div>
   <button class="add-socket-btn" onclick="addSocket('helm')">+</button>
 </div>
 </div>
@@ -130,10 +124,7 @@
               <button id="corruptArmor">Corrupt</button>
               <div id="armor-info" class="item-info"></div>
               <div class="socket-container" data-section="armor">
-                <div class="socket-grid sockets-0">
-  <div class="socket-slot empty" data-index="0"></div>
-  <div class="socket-slot empty" data-index="1"></div>
-</div>
+                <div class="socket-grid sockets-0"></div>
   <button class="add-socket-btn" onclick="addSocket('armor')">+</button>
 </div>
             </div>
@@ -150,10 +141,7 @@
            
             <div id="off-info" class="item-info"></div>
             <div class="socket-container" data-section="shield">
-                <div class="socket-grid sockets-0">
-  <div class="socket-slot empty" data-index="0"></div>
-  <div class="socket-slot empty" data-index="1"></div>
-</div>
+                <div class="socket-grid sockets-0"></div>
   <button class="add-socket-btn" onclick="addSocket('shield')">+</button>
 </div>
             </div>
@@ -476,10 +464,7 @@
               <button id="corruptWeapon">Corrupt</button>
               <div id="merc-weapon-info" class="item-info"></div>
               <div class="socket-container" data-section="mercweapon">
-                <div class="socket-grid sockets-0">
-  <div class="socket-slot empty" data-index="0"></div>
-  <div class="socket-slot empty" data-index="1"></div>
-  </div>
+                <div class="socket-grid sockets-0"></div>
   <button class="add-socket-btn" onclick="addSocket('mercweapon')">+</button>
 </div>
 </div>
@@ -493,10 +478,7 @@
               <button id="corruptHelm">Corrupt</button>
               <div id="merc-helm-info" class="item-info"></div>
               <div class="socket-container" data-section="merchelm">
-                <div class="socket-grid sockets-0">
-  <div class="socket-slot empty" data-index="0"></div>
-  <div class="socket-slot empty" data-index="1"></div>
-  </div>
+                <div class="socket-grid sockets-0"></div>
   <button class="add-socket-btn" onclick="addSocket('merchelm')">+</button>
 </div>
 </div>
@@ -510,10 +492,7 @@
               <button id="corruptArmor">Corrupt</button>
               <div id="merc-armor-info" class="item-info"></div>
               <div class="socket-container" data-section="mercarmor">
-                <div class="socket-grid sockets-0">
-  <div class="socket-slot empty" data-index="0"></div>
-  <div class="socket-slot empty" data-index="1"></div>
-  </div>
+                <div class="socket-grid sockets-0"></div>
   <button class="add-socket-btn" onclick="addSocket('mercarmor')">+</button>
 </div>
 </div>


### PR DESCRIPTION
Previously, clicking the + button on a fresh armor would immediately add 3 sockets and auto-corrupt instead of incrementally adding 1 socket at a time.

Root cause:
- All socket-grid divs in index.html had 2 pre-existing socket-slot divs
- When addSocket() ran, it counted these pre-existing slots: existingSockets = 2
- Adding 1 more: newSocketCount = 3
- This triggered the auto-corruption check for 3rd socket on first click!

Fix:
- Removed ALL pre-existing socket-slot divs from index.html
- Socket grids now start completely empty (sockets-0)
- Fixed for all sections: weapon, helm, armor, shield, mercweapon, merchelm, mercarmor

Now works correctly:
- 1st click: 0 → 1 socket
- 2nd click: 1 → 2 sockets
- 3rd click (armor only): 2 → 3 sockets + auto-applies "Socketed (3)" corruption

All items now start with 0 sockets and add incrementally as expected.