### PR TITLE
Fix: Stat input boxes work correctly on corrupted dynamic items

### DIFF
--- a/corrupt.js
+++ b/corrupt.js
@@ -804,10 +804,13 @@ function addCorruptionWithStacking(originalDescription, corruptionText) {
       description += `<span class="corruption-enhanced-stat">${corruptionText}</span><br>`;
     }
   }
-  
+
   description += '';
   return description;
 }
+
+// Make corruption function available globally
+window.addCorruptionWithStacking = addCorruptionWithStacking;
 
 
 // Parse corruption text into individual stats (same as before)

--- a/main.js
+++ b/main.js
@@ -468,7 +468,22 @@ function handleVariableStatChange(itemName, propKey, newValue, dropdownId, skipR
       if (infoDivId) {
         const infoDiv = document.getElementById(infoDivId);
         if (infoDiv) {
-          infoDiv.innerHTML = generateItemDescription(itemName, item, dropdownId);
+          let description = generateItemDescription(itemName, item, dropdownId);
+
+          // If item has corruption, we need to reapply it to the regenerated description
+          if (window.itemCorruptions && window.itemCorruptions[dropdownId]) {
+            const corruption = window.itemCorruptions[dropdownId];
+            if (corruption.text) {
+              // Get the original description (dynamic, without corruption)
+              const originalDynamic = description;
+              // Add corruption back to the regenerated description
+              if (typeof window.addCorruptionWithStacking === 'function') {
+                description = window.addCorruptionWithStacking(originalDynamic, corruption.text);
+              }
+            }
+          }
+
+          infoDiv.innerHTML = description;
 
           // Re-attach event listeners to the new input boxes
           attachStatInputListeners();


### PR DESCRIPTION
- Modified handleVariableStatChange to regenerate dynamic description with corruption
- When stat inputs change, the description is regenerated dynamically
- Corruption is then reapplied to the fresh dynamic description
- Input boxes now remain fully functional after corruption is applied
- Exposed addCorruptionWithStacking as window.addCorruptionWithStacking for access in main.js
- Corrupted dynamic items now regenerate stats properly on each input change