### PR TITLE
Fix shared build loading to properly trigger stat calculations

### DIFF
--- a/character-data.js
+++ b/character-data.js
@@ -184,10 +184,18 @@ window.loadCharacterFromData = function(data) {
     try {
         // Set basic character info
         const lvlInput = document.getElementById('lvlValue');
-        if (lvlInput) lvlInput.value = data.character.level || 1;
+        if (lvlInput) {
+            lvlInput.value = data.character.level || 1;
+            // Trigger input event to update stats calculations
+            lvlInput.dispatchEvent(new Event('input', { bubbles: true }));
+        }
 
         const classSelect = document.getElementById('selectClass');
-        if (classSelect) classSelect.value = data.character.class || 'Amazon';
+        if (classSelect) {
+            classSelect.value = data.character.class || 'Amazon';
+            // Trigger change event to update class-specific stats
+            classSelect.dispatchEvent(new Event('change', { bubbles: true }));
+        }
 
         // Set base stats
         const strInput = document.getElementById('str');
@@ -195,10 +203,22 @@ window.loadCharacterFromData = function(data) {
         const vitInput = document.getElementById('vit');
         const enrInput = document.getElementById('enr');
 
-        if (strInput) strInput.value = data.character.stats.str || 0;
-        if (dexInput) dexInput.value = data.character.stats.dex || 0;
-        if (vitInput) vitInput.value = data.character.stats.vit || 0;
-        if (enrInput) enrInput.value = data.character.stats.enr || 0;
+        if (strInput) {
+            strInput.value = data.character.stats.str || 0;
+            strInput.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+        if (dexInput) {
+            dexInput.value = data.character.stats.dex || 0;
+            dexInput.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+        if (vitInput) {
+            vitInput.value = data.character.stats.vit || 0;
+            vitInput.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+        if (enrInput) {
+            enrInput.value = data.character.stats.enr || 0;
+            enrInput.dispatchEvent(new Event('input', { bubbles: true }));
+        }
 
         // Set game mode
         const modeDropdown = document.querySelector('.modedropdown');
@@ -210,9 +230,18 @@ window.loadCharacterFromData = function(data) {
             const anyaNM = document.querySelector('input[value="anya-nm"]');
             const anyaH = document.querySelector('input[value="anya-h"]');
 
-            if (anyaN) anyaN.checked = data.anya.n;
-            if (anyaNM) anyaNM.checked = data.anya.nm;
-            if (anyaH) anyaH.checked = data.anya.h;
+            if (anyaN) {
+                anyaN.checked = data.anya.n;
+                anyaN.dispatchEvent(new Event('change', { bubbles: true }));
+            }
+            if (anyaNM) {
+                anyaNM.checked = data.anya.nm;
+                anyaNM.dispatchEvent(new Event('change', { bubbles: true }));
+            }
+            if (anyaH) {
+                anyaH.checked = data.anya.h;
+                anyaH.dispatchEvent(new Event('change', { bubbles: true }));
+            }
         }
 
         // Set mercenary info
@@ -220,8 +249,14 @@ window.loadCharacterFromData = function(data) {
             const mercClassSelect = document.getElementById('mercclass');
             const mercLevelInput = document.getElementById('merclvlValue');
 
-            if (mercClassSelect) mercClassSelect.value = data.mercenary.class || 'No Mercenary';
-            if (mercLevelInput) mercLevelInput.value = data.mercenary.level || 1;
+            if (mercClassSelect) {
+                mercClassSelect.value = data.mercenary.class || 'No Mercenary';
+                mercClassSelect.dispatchEvent(new Event('change', { bubbles: true }));
+            }
+            if (mercLevelInput) {
+                mercLevelInput.value = data.mercenary.level || 1;
+                mercLevelInput.dispatchEvent(new Event('input', { bubbles: true }));
+            }
         }
 
         // Set equipment
@@ -311,15 +346,28 @@ window.loadCharacterFromData = function(data) {
                         input.dispatchEvent(new Event('change', { bubbles: true }));
                     }
                 }
+
+                // Final stats recalculation after all skills are loaded
+                if (window.characterManager) {
+                    window.characterManager.updateTotalStats();
+                    window.characterManager.calculateLifeAndMana();
+                }
             }, 1000);
         }
 
-        // Trigger character manager update
+        // Trigger character manager update immediately
         if (window.characterManager) {
-            window.characterManager.handleClassChange();
             window.characterManager.updateTotalStats();
             window.characterManager.calculateLifeAndMana();
         }
+
+        // Final recalculation after all async operations (charms, skills, etc.)
+        setTimeout(() => {
+            if (window.characterManager) {
+                window.characterManager.updateTotalStats();
+                window.characterManager.calculateLifeAndMana();
+            }
+        }, 1500);
 
         console.log('Character loaded successfully!');
 


### PR DESCRIPTION
When loading a shared build, character stats were showing default level 1 values even though the level input was set correctly. This was because the input values were being set without triggering the necessary change/input events that recalculate stats.

Changes:
- Trigger 'input' event on level and stat inputs (str, dex, vit, enr)
- Trigger 'change' event on class select
- Trigger events on Anya resistance checkboxes
- Trigger events on mercenary class and level inputs
- Add multiple stat recalculations at different timepoints to ensure all async operations (charms, skills, sockets) complete and apply their bonuses
- Remove redundant handleClassChange() call (now handled by event)

This ensures that when a shared build loads, all stats, bonuses, and calculations are properly applied, creating a perfect 1:1 recreation of the original page state.