### PR TITLE
Fix shared build loading issues: stat reset, skill validation, charm …

### DIFF
--- a/character.js
+++ b/character.js
@@ -692,10 +692,14 @@ getDirectLifeManaFromItems() {
 
     if (baseStats) {
       this.currentClass = selectedClass;
-      document.getElementById('str').value = baseStats.str;
-      document.getElementById('dex').value = baseStats.dex;
-      document.getElementById('vit').value = baseStats.vit;
-      document.getElementById('enr').value = baseStats.enr;
+
+      // Only reset stats to base values if NOT loading character data
+      if (!window._isLoadingCharacterData) {
+        document.getElementById('str').value = baseStats.str;
+        document.getElementById('dex').value = baseStats.dex;
+        document.getElementById('vit').value = baseStats.vit;
+        document.getElementById('enr').value = baseStats.enr;
+      }
 
       this.updateTotalStats();
       this.updateStatPointsDisplay();

--- a/inventory.js
+++ b/inventory.js
@@ -49,7 +49,16 @@ class CharmInventory {
       document.body.appendChild(container);
     }
 
-    container.innerHTML = '';
+    // Only clear if container is empty or doesn't have the right structure
+    // This prevents clearing charms that were already placed
+    if (container.children.length !== 40) {
+      container.innerHTML = '';
+    }
+
+    // If grid already exists with 40 slots, don't recreate it
+    if (container.children.length === 40) {
+      return;
+    }
 
     // Seamless grid without gaps
     container.style.cssText = `


### PR DESCRIPTION
…clearing

Fixed multiple critical bugs that were introduced in the previous commit when adding event dispatching to trigger calculations during build loading.

Issues Fixed:

1. **Stats resetting when changing level**
   - Problem: Class change event was resetting stats to base class values
   - Solution: Added `window._isLoadingCharacterData` flag to prevent stat reset during character data loading
   - Modified: character.js handleClassChange() to check flag before resetting

2. **Skill points exceeding validation limits**
   - Problem: Dispatching 'change' events bypassed skill input validation
   - Solution: Remove event dispatching for skills, just set values directly
   - Skill validation (max 20 points, level requirements) now works correctly
   - The skill system validates on actual user 'input' events, not 'change'

3. **Charms not appearing in inventory**
   - Problem: createInventoryGrid() was clearing container.innerHTML every call
   - Solution: Check if 40 slots already exist before clearing/recreating
   - Prevents charm data from being wiped when grid is re-initialized
   - Modified: inventory.js createInventoryGrid()

4. **Removed unnecessary event dispatching**
   - Base stats (str/dex/vit/enr): Set values without events, recalc at end
   - Anya bonuses: Set checkboxes and update global checkboxResistBonus directly
   - Mercenary: Set values without events
   - Skills: Set values without triggering validation bypass

5. **Improved calculation timing**
   - Single recalculation after all values are set
   - Explicit unifiedSocketSystem.updateAll() call
   - Clear loading flag after all async operations complete (1500ms)

This ensures proper validation, correct stat calculations, and preserved charm inventory when loading shared builds.