### PR TITLE
Fix charm restoration and skill validation issues

### DIFF
--- a/character-data.js
+++ b/character-data.js
@@ -305,15 +305,29 @@ window.loadCharacterFromData = function(data) {
             window.itemCorruptions = data.corruptions.data;
         }
 
-        // Restore charms
-        if (data.charms && window.charmInventory) {
-            setTimeout(() => {
-                data.charms.forEach(charm => {
-                    if (window.charmInventory.restoreCharm) {
-                        window.charmInventory.restoreCharm(charm);
+        // Restore charms (wait for charm inventory to be fully initialized)
+        if (data.charms && data.charms.length > 0) {
+            const restoreCharmsWhenReady = () => {
+                if (window.charmInventory && window.charmInventory.initialized) {
+                    const container = document.querySelector('.inventorycontainer');
+                    if (container && container.children.length === 40) {
+                        console.log('Restoring', data.charms.length, 'charms');
+                        data.charms.forEach(charm => {
+                            if (window.charmInventory.restoreCharm) {
+                                window.charmInventory.restoreCharm(charm);
+                            }
+                        });
+                    } else {
+                        console.warn('Charm inventory grid not ready, retrying...');
+                        setTimeout(restoreCharmsWhenReady, 200);
                     }
-                });
-            }, 1000);
+                } else {
+                    console.warn('Charm inventory not initialized, retrying...');
+                    setTimeout(restoreCharmsWhenReady, 200);
+                }
+            };
+
+            setTimeout(restoreCharmsWhenReady, 500);
         }
 
         // Restore skills (just set values without triggering validation)

--- a/inventory.js
+++ b/inventory.js
@@ -49,15 +49,17 @@ class CharmInventory {
       document.body.appendChild(container);
     }
 
-    // Only clear if container is empty or doesn't have the right structure
+    // If grid already exists with 40 slots, don't recreate it
     // This prevents clearing charms that were already placed
-    if (container.children.length !== 40) {
-      container.innerHTML = '';
+    if (container.children.length === 40) {
+      console.log('Charm inventory grid already exists, skipping recreation');
+      return;
     }
 
-    // If grid already exists with 40 slots, don't recreate it
-    if (container.children.length === 40) {
-      return;
+    // Only clear and recreate if needed
+    if (container.children.length > 0 && container.children.length !== 40) {
+      console.warn('Charm inventory has wrong number of slots, recreating');
+      container.innerHTML = '';
     }
 
     // Seamless grid without gaps

--- a/skills.js
+++ b/skills.js
@@ -644,12 +644,21 @@ getDeadlyStrikeChance() {
     var skillLevel = parseInt(input.getAttribute('data-skill-level')) || 1;
     var maxAllowed = this.getMaxAllowed(skillLevel);
 
+    // Enforce absolute maximum of 20 points per skill
+    if (newValue > 20) {
+      input.value = 20;
+      this.showWarning('Maximum 20 points per skill');
+      newValue = 20;
+    }
+
+    // Enforce character level-based maximum
     if (newValue > maxAllowed) {
       input.value = maxAllowed;
       this.showWarning('Max ' + maxAllowed + ' points at level ' + this.currentLevel);
       return;
     }
 
+    // Enforce total skill points available
     var totalUsed = this.getTotalUsed();
     if (totalUsed > this.maxSkillPoints) {
       var excess = totalUsed - this.maxSkillPoints;


### PR DESCRIPTION
Fixed two critical bugs in shared build loading:

1. **Charm Inventory Not Restoring**
   - Problem: Charms were not appearing when loading shared builds
   - Root cause: Timing race between charm restoration and grid initialization
   - Solution:
     * Added retry mechanism in character-data.js to wait for charm inventory
     * Checks: window.charmInventory exists, initialized flag, 40 grid slots ready * Retries every 200ms until ready, then restores all charms * Added console logging to track restoration progress

2. **Skills Exceeding 20 Point Maximum**
   - Problem: Using arrow keys/spinner buttons bypassed validation
   - Root cause: HTML input type="number" doesn't enforce max attribute
   - Solution:
     * Added absolute 20-point check at start of handleSkillInput()
     * Enforces: newValue > 20 → set to 20 immediately * Prevents any input method from bypassing the limit * Still maintains level-based and total points validation

3. **Improved Inventory Grid Protection**
   - Reorganized createInventoryGrid() logic for clarity
   * Early return if 40 slots already exist (with console log)
   * Only clear if slot count is wrong (with warning)
   * Prevents accidental charm clearing on re-initialization

Testing notes:
- Charms should now persist when loading shared builds
- Skills cannot exceed 20 points via any input method
- Console logs help debug charm restoration timing