### PR TITLE
Fix charm data storage to use JSON instead of display strings

### DIFF
--- a/inventory.js
+++ b/inventory.js
@@ -957,7 +957,12 @@ createManualCharm() {
     if (suffixStatLine) stats.push(suffixStatLine);
   }
 
-  const charmData = `${charmName}\n${stats.join('\n')}`;
+  // Store charm data as JSON object instead of formatted string
+  const charmData = JSON.stringify({
+    name: charmName,
+    stats: stats,
+    displayText: `${charmName}\n${stats.join('\n')}`
+  });
   const backgroundImage = `url('${this.getRandomCharmImage(this.selectedCharmType)}')`;
 
   this.placeCharm(position, this.selectedCharmType, backgroundImage, charmData);


### PR DESCRIPTION
Changed charm data storage from formatted text to JSON object:
- Old: 'Small Charm of Strength\n+1 to Strength'
- New: {"name": "Small Charm of Strength", "stats": ["+1 to Strength"]}

This allows proper serialization/deserialization for sharing builds. The JSON object includes the charm name and stats array for export/import.