### PR TITLE
Fix charm restoration infinite retry and add display text tooltips

### DIFF
--- a/character-data.js
+++ b/character-data.js
@@ -278,7 +278,9 @@ window.loadCharacterFromData = function(data) {
 
                 if (window.charmInventory && window.charmInventory.initialized) {
                     const container = document.querySelector('.inventorycontainer');
-                    if (container && container.children.length === 40) {
+                    // Count actual charm slots (.charm1 elements), not total children (which include overlays)
+                    const charmSlots = container?.querySelectorAll('.charm1').length ?? 0;
+                    if (container && charmSlots >= 40) {
                         console.log('Charm inventory ready! Using restoreAllCharms method');
                         // Use the new method that handles everything internally
                         if (window.charmInventory.restoreAllCharms) {
@@ -296,7 +298,7 @@ window.loadCharacterFromData = function(data) {
                     } else {
                         console.warn('Charm inventory grid not ready, retrying...', {
                             containerExists: !!container,
-                            slotCount: container?.children.length
+                            charmSlots: charmSlots
                         });
                         setTimeout(() => restoreCharmsWhenReady(attempt + 1), 200);
                     }

--- a/inventory.js
+++ b/inventory.js
@@ -1183,6 +1183,16 @@ placeCharm(position, charmType, backgroundImage, charmData) {
   const container = document.querySelector('.inventorycontainer');
   const mainSlot = container.children[position];
 
+  // Parse charm data to extract display text for tooltip
+  let displayText = '';
+  try {
+    const data = JSON.parse(charmData);
+    displayText = data.displayText || data.name || '';
+  } catch (e) {
+    // If it's old format or plain text, use as-is
+    displayText = charmData;
+  }
+
   // Calculate position
   const row = Math.floor(position / 10);
   const col = position % 10;
@@ -1193,6 +1203,7 @@ placeCharm(position, charmType, backgroundImage, charmData) {
     mainSlot.style.backgroundImage = backgroundImage;
     mainSlot.classList.add(charmType);
     mainSlot.dataset.charmData = charmData;
+    mainSlot.title = displayText;
   } else {
     // Large/Grand charm - create overlay element
     const charmOverlay = document.createElement('div');
@@ -1216,6 +1227,7 @@ placeCharm(position, charmType, backgroundImage, charmData) {
     charmOverlay.classList.add('charm-overlay', charmType);
     charmOverlay.dataset.charmData = charmData;
     charmOverlay.dataset.position = position;
+    charmOverlay.title = displayText;
 
     // Add to container
     container.appendChild(charmOverlay);


### PR DESCRIPTION
**Changes:**

1. **Fixed infinite retry loop** (character-data.js)
   - Changed slot count check from == 40 to >= 40
   - Count only .charm1 elements, not all children (which include overlay divs)
   - This fixes the case when loading a shared build with existing charms

2. **Added display text tooltips** (inventory.js)
   - Extract displayText from JSON charm data
   - Set it as HTML title attribute on charm elements
   - Hovering shows 'Small Charm of Strength' instead of raw JSON
   - Works for both small charms and overlay (large/grand) charms
   - Gracefully handles old format data by using charmData as-is

Now when you hover over charms, you see the nice formatted text, and loading a shared build while having charms won't retry infinitely.