### PR TITLE
Fix True Silver weapon damage NaN display

### DIFF
--- a/itemUpgrade.js
+++ b/itemUpgrade.js
@@ -4128,6 +4128,7 @@ function updateWeaponDamageDisplay() {
     let description = currentItemData.description;
     if (!description && currentItemData.baseType) {
       description = window.generateItemDescription(currentItem, currentItemData, 'weapons-dropdown');
+      currentItemData.description = description;
     }
 
     if (!description) return;
@@ -4601,6 +4602,12 @@ function updateWeaponTooltip(currentItemData, baseType, isTwoHanded) {
   const avg = ((min + max) / 2).toFixed(1);
   const damageType = isTwoHanded ? "Two-Hand" : "One-Hand";
 
+  // Ensure description exists before parsing
+  if (!currentItemData.description) {
+    console.warn("updateWeaponTooltip: description is undefined for item", currentItemData);
+    return;
+  }
+
   // Parse the current description
   const lines = currentItemData.description.split("<br>");
 
@@ -4684,6 +4691,7 @@ function updateWeaponDisplayWithPerLevelDamage() {
   let description = currentItemData.description;
   if (!description && currentItemData.baseType) {
     description = window.generateItemDescription(selectedWeapon, currentItemData, 'weapons-dropdown');
+    currentItemData.description = description;
   }
 
   if (!description) return;


### PR DESCRIPTION
When updating weapon damage displays for dynamic items (like True Silver), the generated description was stored in a local variable but not assigned back to currentItemData.description. This caused updateWeaponTooltip() and updateWeaponDisplayWithPerLevelDamage() to fail when trying to parse the undefined description, resulting in "Cannot read properties of undefined (reading 'split')" errors and NaN damage display.

Fixes:
- Assign generated description to currentItemData.description in updateWeaponDamageDisplay()
- Assign generated description to currentItemData.description in updateWeaponDisplayWithPerLevelDamage()
- Add safety check in updateWeaponTooltip() to handle undefined descriptions gracefully