### PR TITLE
Fix NaN damage calculation for dynamic items with object properties

### DIFF
--- a/itemUpgrade.js
+++ b/itemUpgrade.js
@@ -2936,8 +2936,11 @@ function calculateItemDamage(item, baseType, isMax = false) {
   // Get base damage from the damage table
   const baseDamage = baseDamages[baseType.trim()] || { min: 0, max: 0 };
 
-  // Get the base enhanced damage from the item
-  const itemEdmg = item.properties?.edmg || 0;
+  // Get the base enhanced damage from the item (extract current value if it's an object)
+  let itemEdmg = item.properties?.edmg || 0;
+  if (typeof itemEdmg === 'object' && itemEdmg !== null && 'current' in itemEdmg) {
+    itemEdmg = itemEdmg.current;
+  }
 
   // Check if item is ethereal
   const isEthereal = item.description && item.description.includes("Ethereal");


### PR DESCRIPTION
For dynamic items like True Silver, the edmg property is stored as an object { min: 80, max: 120, current: 120 }, not a scalar value. calculateItemDamage was treating it as a number, causing NaN in damage calculations.

Extract the current value from edmg if it's an object before using it in arithmetic operations. This matches how other parts of the code (like generateItemDescription) handle variable properties.