### PR TITLE
Fix dynamic item descriptions to regenerate with current property values

### DIFF
--- a/itemUpgrade.js
+++ b/itemUpgrade.js
@@ -4127,11 +4127,16 @@ function updateWeaponDamageDisplay() {
   const currentItemData = itemList[currentItem];
 
   if (currentItemData) {
-    // Get description (generate if dynamic item)
-    let description = currentItemData.description;
-    if (!description && currentItemData.baseType) {
+    // Get description - for dynamic items always regenerate to reflect current property values
+    let description;
+    const isDynamic = currentItemData.baseType;
+
+    if (isDynamic) {
+      // Dynamic items (with baseType) must always regenerate to show current values
       description = window.generateItemDescription(currentItem, currentItemData, 'weapons-dropdown');
-      currentItemData.description = description;
+    } else {
+      // Static items can use cached description
+      description = currentItemData.description;
     }
 
     if (!description) return;
@@ -4735,11 +4740,16 @@ function updateWeaponDisplayWithPerLevelDamage() {
 
   if (!currentItemData) return;
 
-  // Get description (generate if dynamic item)
-  let description = currentItemData.description;
-  if (!description && currentItemData.baseType) {
+  // Get description - for dynamic items always regenerate to reflect current property values
+  let description;
+  const isDynamic = currentItemData.baseType;
+
+  if (isDynamic) {
+    // Dynamic items (with baseType) must always regenerate to show current values
     description = window.generateItemDescription(selectedWeapon, currentItemData, 'weapons-dropdown');
-    currentItemData.description = description;
+  } else {
+    // Static items can use cached description
+    description = currentItemData.description;
   }
 
   if (!description) return;


### PR DESCRIPTION
Dynamic items with baseType (like True Silver) must ALWAYS regenerate their descriptions to reflect current property values when properties change (e.g., when user adjusts enhanced damage % via input).

Previously, descriptions were cached on currentItemData.description after first generation, causing them to always show max values and preventing updates when user changes inputs. This broke URL sharing with selected values.

Changed updateWeaponDamageDisplay and updateWeaponDisplayWithPerLevelDamage to:
- Always regenerate descriptions for dynamic items (isDynamic check)
- Use cached descriptions only for static items
- Matches the pattern used by generateItemDescription itself

This ensures True Silver and other dynamic weapons show current values in the description, not frozen max values.