### PR TITLE
Fix real-time weapon stat updates and damage line positioning

### DIFF
--- a/main.js
+++ b/main.js
@@ -497,6 +497,11 @@ function handleVariableStatChange(itemName, propKey, newValue, dropdownId, skipR
     if (window.unifiedSocketSystem && typeof window.unifiedSocketSystem.updateAll === 'function') {
       window.unifiedSocketSystem.updateAll();
     }
+
+    // Update weapon damage display if this is a weapon stat change
+    if (dropdownId === 'weapons-dropdown' && typeof window.updateWeaponDamageDisplay === 'function') {
+      window.updateWeaponDamageDisplay();
+    }
   }
 }
 


### PR DESCRIPTION
Two major issues fixed:

1. Real-time stat updates: When user changed dynamic stat inputs (like enhanced damage %), the weapon display wasn't updating. Added call to updateWeaponDamageDisplay() in handleVariableStatChange() so stat input changes trigger weapon display updates immediately.

2. Damage line positioning: Damage lines were appearing at the bottom of descriptions. Fixed by calculating damage BEFORE regenerating the description, ensuring damage properties exist when generateItemDescription is called. This puts damage lines in the correct position in the description.

Flow for dynamic items (like True Silver):
1. Generate temp description to get base type
2. Calculate damage (stores in onehandmin/max properties)
3. Regenerate description with calculated damage
4. Update weapon tooltip display

This ensures:
- Damage shows at correct position (near top, not bottom)
- Values update instantly when user changes stat inputs
- URLs save with current values, not cached max values