### PR TITLE
Fix dynamic item stat inputs and damage line positioning

### DIFF
--- a/itemUpgrade.js
+++ b/itemUpgrade.js
@@ -4213,6 +4213,11 @@ function updateWeaponDamageDisplay() {
 
     // Update the tooltip/description
     updateWeaponTooltip(currentItemData, baseType, isTwoHanded);
+
+    // Re-attach event listeners to stat input boxes in the weapon info
+    if (typeof window.attachStatInputListeners === 'function') {
+      window.attachStatInputListeners();
+    }
   }
 }
 
@@ -4920,6 +4925,11 @@ function updateWeaponDisplayWithPerLevelDamage() {
     const maxContainer = document.getElementById("onehandmaxdmgcontainer");
     if (minContainer) minContainer.textContent = min;
     if (maxContainer) maxContainer.textContent = max;
+  }
+
+  // Re-attach event listeners to stat input boxes in the weapon info
+  if (typeof window.attachStatInputListeners === 'function') {
+    window.attachStatInputListeners();
   }
 }
 

--- a/main.js
+++ b/main.js
@@ -403,15 +403,17 @@ window.generateItemDescription = function generateItemDescription(itemName, item
   // Skip certain properties that are metadata or handled elsewhere
   const skipProperties = ['javelin', 'speed', 'onehandmax', 'throwmax'];
 
-  for (const [key, prop] of Object.entries(props)) {
+  // Iterate through propertyDisplay keys in order to control display order
+  // This ensures damage lines appear in the correct position, not at the end
+  for (const key of Object.keys(propertyDisplay)) {
     if (skipProperties.includes(key)) continue;
+    if (!(key in props)) continue;
 
-    if (propertyDisplay[key]) {
-      const value = getPropertyValue(prop);
-      const displayText = propertyDisplay[key](value, prop);
-      if (displayText) { // Skip empty strings (for properties that are already handled)
-        html += displayText + '<br>';
-      }
+    const prop = props[key];
+    const value = getPropertyValue(prop);
+    const displayText = propertyDisplay[key](value, prop);
+    if (displayText) { // Skip empty strings (for properties that are already handled)
+      html += displayText + '<br>';
     }
   }
 


### PR DESCRIPTION
Fixed two critical issues with dynamic items like True Silver:

1. Stat inputs not updating: When user changed dynamic stat inputs (like enhanced damage %), the weapon display wasn't updating because new input elements created during description regeneration didn't have event listeners. Now attachStatInputListeners() is called after each weapon display update to re-attach listeners to new inputs.

2. Damage line at bottom instead of correct position: Properties were being iterated in insertion order (Object.entries), causing damage lines to appear at the end. Changed generateItemDescription to iterate through propertyDisplay keys instead, which controls the order.

   This ensures damage appears in the correct position (after base type, before other stats).

Changes:
- generateItemDescription now iterates propertyDisplay keys in order
- updateWeaponDamageDisplay re-attaches listeners after updates
- updateWeaponDisplayWithPerLevelDamage re-attaches listeners after updates
- Listeners now persist through description regeneration cycles

This fixes stat input changes triggering immediate weapon display updates and positions damage lines correctly at the top of descriptions.