### PR TITLE
Generate and return authentication token on user registration

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -60,7 +60,7 @@ class Auth {
                 throw new Error(data.error || 'Registration failed');
             }
 
-            this.saveUser(data.user);
+            this.saveUser(data.user, data.token);
             return { success: true, user: data.user };
         } catch (error) {
             return { success: false, error: error.message };

--- a/cloudflare-worker/worker.js
+++ b/cloudflare-worker/worker.js
@@ -131,9 +131,19 @@ async function handleRequest(request, env) {
           VALUES (${result[0].id}, true)
         `;
 
+        // Generate session token for new user
+        const token = generateToken();
+        const userId = result[0].id;
+
+        await sql`
+          INSERT INTO session_tokens (user_id, token, expires_at)
+          VALUES (${userId}, ${token}, NOW() + INTERVAL '30 days')
+        `;
+
         return new Response(JSON.stringify({
           success: true,
-          user: result[0]
+          user: result[0],
+          token: token
         }), {
           headers: { ...corsHeaders, 'Content-Type': 'application/json' }
         });


### PR DESCRIPTION
- Updated register endpoint to generate session token like login does
- Token stored in session_tokens table with 30-day expiration
- Updated auth.js to save token from registration response
- Allows newly registered users to immediately save characters with authentication