### PR TITLE
Fix item stat requirements validation, should be simple fix

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -2747,12 +2747,13 @@ this.selectedJewelSuffix3MaxValue = null;
     calculateEquipmentStats(dropdownId, section) {
       const dropdown = document.getElementById(dropdownId);
       if (!dropdown || !dropdown.value || !itemList[dropdown.value]) return;
-      
+
       const item = itemList[dropdown.value];
       const actualLevel = this.calculateActualRequiredLevel(section, dropdown.value);
-      
-      // Only apply stats if level requirement is met
-      if (this.currentLevel >= actualLevel && item.properties) {
+      const meetsStatRequirements = this.doesCharacterMeetStatRequirements(dropdown.value);
+
+      // Only apply stats if level and stat requirements (strength/dexterity) are met
+      if (this.currentLevel >= actualLevel && meetsStatRequirements && item.properties) {
         this.parseItemStats(item, section);
       }
     }


### PR DESCRIPTION
Items were being included in character stat calculations even when the player didn't meet strength/dexterity requirements. Now properly checks all requirements (level, strength, and dexterity) before applying item stats to the character calculator.

Fixed in calculateEquipmentStats() method in socket.js:
- Added doesCharacterMeetStatRequirements() check
- Items with opacity 0.5 (unusable) no longer contribute stats
- Stats only apply when ALL requirements are met