### PR TITLE
Separate curse resistance from all resistances

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -2781,14 +2781,14 @@ this.selectedJewelSuffix3MaxValue = null;
         }
       });
     });
-    
-    
-    // Add checkbox bonus ONCE at the end
+
+
+    // Add checkbox bonus ONCE at the end (Anya quest - does NOT apply to curse resistance)
     this.stats.fireResist += window.checkboxResistBonus || 0;
     this.stats.coldResist += window.checkboxResistBonus || 0;
     this.stats.lightResist += window.checkboxResistBonus || 0;
     this.stats.poisonResist += window.checkboxResistBonus || 0;
-    this.stats.curseResist += window.checkboxResistBonus || 0;
+    // Curse resistance is NOT affected by Anya checkbox bonus
   }
 
     parseItemStats(item, section) {
@@ -3026,7 +3026,7 @@ if (defMatch) {
       this.stats.coldResist += value;
       this.stats.lightResist += value;
       this.stats.poisonResist += value;
-      this.stats.curseResist += value;
+      // Curse resistance is NOT included in "All Resistances"
       return;
     }
 


### PR DESCRIPTION
Curse resistance is now completely separate from fire/cold/lightning/poison resistances and is NOT affected by:
- "All Resistances" bonuses (e.g., Crown of Ages, Saracen's Chance)
- Anya quest checkbox bonuses

Curse resistance is only gained from items that specifically grant "Curse Resistance" (e.g., Spirit Shroud +10%, Rune Master +20%).

Changes in socket.js:
- Line 3029: Removed curseResist from "All Resistances" bonus
- Line 2791: Removed curseResist from Anya checkbox bonus