### PR TITLE
Fix parseStatLine to skip set bonus lines - prevents double application

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -2879,11 +2879,16 @@ this.selectedJewelSuffix3MaxValue = null;
 
    parseStatLine(line) {
   if (!line) return;
-  
+
   const cleanLine = line.replace(/<[^>]*>/g, '').trim();
   if (!cleanLine) return;
-  
-  
+
+  // IMPORTANT: Skip set bonus lines - these are handled by setTracker.js
+  // Set bonuses have patterns like "(2 Items)", "(3 Items)", "(Complete Set)"
+  if (/\(\d+\s+Items?\)|\(Complete Set\)/i.test(cleanLine)) {
+    return; // Skip this line entirely
+  }
+
   try {
     // === RAINBOW FACET PATTERNS FIRST (most specific) ===
     


### PR DESCRIPTION
The issue was that parseStatLine in socket.js was parsing ALL lines from item descriptions, including set bonus lines like '+20 to Energy (3 Items)'. This caused set bonuses to be applied even when the requirements weren't met.

Fix:
- Added regex check at start of parseStatLine to detect set bonus patterns
- Patterns: (2 Items), (3 Items), (Complete Set), etc.
- These lines are now skipped entirely in the regular stat parser
- setTracker.js handles all set bonuses exclusively with proper requirement checking

This prevents the energy bonus from appearing when wearing only 2/3 Arcanna items.