### PR TITLE
Remove set bonus properties from Arcanna's Flesh in items.js

### DIFF
--- a/items.js
+++ b/items.js
@@ -1576,9 +1576,10 @@ const itemList = {
       fcr: 10,
       pdr: 6,
       ligrad: 2,
-      todef: 100,
-      enr: 20,
-      regmana: 20, //fullset
+      // Set bonuses removed - handled by setTracker.js:
+      // todef: 100,  // (2 Items)
+      // enr: 20,     // (3 Items)
+      // regmana: 20, // (Complete Set)
     },
   },
 


### PR DESCRIPTION
The real issue: Set bonuses were stored in BOTH the description AND the properties object. Even though we skip parsing set bonus lines from descriptions, the properties object values (enr: 20, todef: 100, regmana: 20) were still being applied directly.

Fix: Removed set bonus properties from the properties object. Set bonuses are now ONLY in the description text and handled exclusively by setTracker.js.

This prevents +20 Energy (3 Items) from applying when only wearing 2 Arcanna items.