### PR TITLE
Remove duplicate Arcanna's Deathwand definition that lacked setBonuses

### DIFF
--- a/corrupt.js
+++ b/corrupt.js
@@ -199,6 +199,9 @@ const SECTION_MAP = {
   'mercboots-dropdown': 'mercboots'
 };
 
+// Make SECTION_MAP globally accessible for main.js
+window.SECTION_MAP = SECTION_MAP;
+
 // Global variables
 let currentCorruptionSlot = null;
 

--- a/items.js
+++ b/items.js
@@ -3120,23 +3120,6 @@ const itemList = {
     },
   },
 
-  "Arcanna's Deathwand": {
-    baseType: "War Staff", // this has +75 to Mana (2 Items)	Regenerate Mana 20% (3 Items) +40% Increased Attack Speed (Complete Set)
-    properties: {
-      speed: 20,
-      twohandmin: 21,
-      twohandmax: 49,
-      reqlvl: 15,
-      ctcbonespearcast: 15, //bone spear on casting
-      ctcbonespearcastlevel: 2,
-      sorsk: 1,
-      fcr: 10,
-      edmg: { min: 50, max: 75, current: 75 },
-      deadly: { min: 25, max: 50, current: 25 },
-      dmgtoun: 50
-    },
-  },
-
   "Knell Striker": {
     description:
       "Knell Striker<br> Scepter<br> Base Damage: 6 to 11<br> Base Speed Modifier: 0<br> Base Maximum Sockets: 2<br> One-Hand Damage: 10 to 19, Avg 14.5<br> Required Strength: 25<br> Required Level: 5<br> +80% Enhanced Damage<br> +35 to Attack Rating<br> 25% Chance of Crushing Blow<br> +15 to Mana<br> Fire Resist +20%<br> Poison Resist +20%<br> +50% Damage to Undead<br>",

--- a/main.js
+++ b/main.js
@@ -631,7 +631,7 @@ window.updateItemInfo = function updateItemInfo(event) {
   }
 
   // Adjust socket count for new item if needed, then update socket system
-  const section = SECTION_MAP[dropdown.id];
+  const section = window.SECTION_MAP && window.SECTION_MAP[dropdown.id];
   if (section && window.unifiedSocketSystem) {
     try {
       // Adjust socket count to match new item's max


### PR DESCRIPTION
The duplicate definition at line 3123 was missing the setBonuses property that's required for proper set tracking and dynamic stats display. The correct definition at line 5593 with all required properties has been preserved.

This fixes the issue where Arcanna's Deathwand dynamic stats (enhanced damage and deadly strike) were showing as static values instead of updating when input values changed.