### PR TITLE
Fix dynamic item properties getting stuck when switching items

### DIFF
--- a/main.js
+++ b/main.js
@@ -619,6 +619,17 @@ window.updateItemInfo = function updateItemInfo(event) {
   const item = itemList && itemList[selectedItemName];
 
   if (item) {
+    // Reset any .current values for dynamic items to ensure fresh regeneration
+    // This prevents values from "sticking" when switching between items
+    if (item.properties && item.baseType) {
+      Object.keys(item.properties).forEach(key => {
+        const prop = item.properties[key];
+        if (typeof prop === 'object' && prop !== null && 'current' in prop) {
+          delete prop.current;
+        }
+      });
+    }
+
     // Generate description (handles both static and dynamic with variable stats)
     const description = generateItemDescription(selectedItemName, item, dropdown.id);
     infoDiv.innerHTML = description;


### PR DESCRIPTION
The issue was that when variable stats (like ED or deadly strike on Arcanna's Deathweb) were adjusted, the values were stored in prop.current which directly modified the global itemList object. When switching to another item and back, these .current values persisted, causing the properties to appear "stuck" at their previous values instead of regenerating with fresh defaults.

The fix resets all .current values when switching items, ensuring dynamic items always regenerate with their default (max) values. Users can then adjust these values as needed, and they'll properly reset on the next item switch.