### PR TITLE
Fix mercenary dropdown stats bug - separate merc and player stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -554,8 +554,87 @@
              </div>
               </div>
 
+              <!-- Mercenary Stats Display -->
+              <div class="mercenary-stats-display">
+                <h4>Mercenary Stats</h4>
+                <div class="merc-stats-grid">
+                  <div class="merc-stat-row">
+                    <span class="merc-stat-label">All Skills:</span>
+                    <span id="merc-allskills" class="merc-stat-value">0</span>
+                  </div>
+                  <div class="merc-stat-row">
+                    <span class="merc-stat-label">MF:</span>
+                    <span id="merc-mf" class="merc-stat-value">0</span>
+                  </div>
+                  <div class="merc-stat-row">
+                    <span class="merc-stat-label">GF:</span>
+                    <span id="merc-gf" class="merc-stat-value">0</span>
+                  </div>
+                  <div class="merc-stat-row">
+                    <span class="merc-stat-label">Defense:</span>
+                    <span id="merc-defense" class="merc-stat-value">0</span>
+                  </div>
+                  <div class="merc-stat-row">
+                    <span class="merc-stat-label">DR:</span>
+                    <span id="merc-dr" class="merc-stat-value">0</span>
+                  </div>
+                  <div class="merc-stat-row">
+                    <span class="merc-stat-label">PDR:</span>
+                    <span id="merc-pdr" class="merc-stat-value">0</span>
+                  </div>
+                  <div class="merc-stat-row">
+                    <span class="merc-stat-label">MDR:</span>
+                    <span id="merc-mdr" class="merc-stat-value">0</span>
+                  </div>
+                  <div class="merc-stat-row">
+                    <span class="merc-stat-label">PLR:</span>
+                    <span id="merc-plr" class="merc-stat-value">0</span>
+                  </div>
+                  <div class="merc-stat-row">
+                    <span class="merc-stat-label">Cannot be Frozen:</span>
+                    <span id="merc-cbf" class="merc-stat-value">No</span>
+                  </div>
+                  <div class="merc-stat-row">
+                    <span class="merc-stat-label">IAS:</span>
+                    <span id="merc-ias" class="merc-stat-value">0</span>
+                  </div>
+                  <div class="merc-stat-row">
+                    <span class="merc-stat-label">FCR:</span>
+                    <span id="merc-fcr" class="merc-stat-value">0</span>
+                  </div>
+                  <div class="merc-stat-row">
+                    <span class="merc-stat-label">FRW:</span>
+                    <span id="merc-frw" class="merc-stat-value">0</span>
+                  </div>
+                  <div class="merc-stat-row">
+                    <span class="merc-stat-label">FHR:</span>
+                    <span id="merc-fhr" class="merc-stat-value">0</span>
+                  </div>
+                  <div class="merc-stat-row">
+                    <span class="merc-stat-label">Fire Resist:</span>
+                    <span id="merc-fire-res" class="merc-stat-value">0</span>
+                  </div>
+                  <div class="merc-stat-row">
+                    <span class="merc-stat-label">Cold Resist:</span>
+                    <span id="merc-cold-res" class="merc-stat-value">0</span>
+                  </div>
+                  <div class="merc-stat-row">
+                    <span class="merc-stat-label">Light Resist:</span>
+                    <span id="merc-light-res" class="merc-stat-value">0</span>
+                  </div>
+                  <div class="merc-stat-row">
+                    <span class="merc-stat-label">Poison Resist:</span>
+                    <span id="merc-poison-res" class="merc-stat-value">0</span>
+                  </div>
+                  <div class="merc-stat-row">
+                    <span class="merc-stat-label">Curse Resist:</span>
+                    <span id="merc-curse-res" class="merc-stat-value">0</span>
+                  </div>
+                </div>
+              </div>
 
-    
+
+
         <!-- <div class="auth-container">
             <form id="loginForm" onsubmit="handleLogin(event)">
                 <h2>Login</h2>

--- a/style.css
+++ b/style.css
@@ -1040,9 +1040,52 @@ body.moody .stat-group h4 {
     font-size: 12px;
     padding: 8px 12px;
   }
-  
+
 .buff-tooltip .buff-name {
     font-size: 14px;
   } */
 
+}
+
+/* Mercenary Stats Display */
+.mercenary-stats-display {
+  margin-top: 20px;
+  padding: 15px;
+  background: rgba(30, 30, 30, 0.8);
+  border: 2px solid #8B4513;
+  border-radius: 8px;
+}
+
+.mercenary-stats-display h4 {
+  margin: 0 0 15px 0;
+  color: #ffd700;
+  text-align: center;
+  font-size: 16px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.merc-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+}
+
+.merc-stat-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 8px;
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 4px;
+}
+
+.merc-stat-label {
+  color: #aaa;
+  font-size: 13px;
+}
+
+.merc-stat-value {
+  color: #fff;
+  font-weight: bold;
+  font-size: 13px;
 }


### PR DESCRIPTION
- Added separate mercenaryStats object to track mercenary equipment stats independently
- Modified calculateAllStats() to filter out mercenary equipment from player stats
- Created calculateMercenaryStats(), parseMercenaryItemStats(), and parseMercenaryStatLine() methods
- Added mercenary stats display UI showing all skills, MF, GF, defense, resistances, DR, PDR, MDR, PLR, CBF, IAS, FCR, FRW, FHR
- Mercenary items no longer affect player's character stats counter
- Save/export functionality unchanged - mercenary equipment still saved properly