### PR TITLE
Fix mercenary stats display layout - move inside mercenary section

### DIFF
--- a/index.html
+++ b/index.html
@@ -633,6 +633,8 @@
                 </div>
               </div>
 
+              </div>
+
 
 
         <!-- <div class="auth-container">

--- a/style.css
+++ b/style.css
@@ -383,6 +383,9 @@ body {
   border-radius: 10px;
   padding: 20px;
   height: fit-content;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
 }
 
 .mercequipment-container {
@@ -391,7 +394,7 @@ body {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 20px;
-  
+
 }
 
 .mercequipment-container > *:nth-child(7) {
@@ -1049,11 +1052,11 @@ body.moody .stat-group h4 {
 
 /* Mercenary Stats Display */
 .mercenary-stats-display {
-  margin-top: 20px;
   padding: 15px;
   background: rgba(30, 30, 30, 0.8);
   border: 2px solid #8B4513;
   border-radius: 8px;
+  width: 100%;
 }
 
 .mercenary-stats-display h4 {
@@ -1067,7 +1070,7 @@ body.moody .stat-group h4 {
 
 .merc-stats-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: 8px;
 }
 


### PR DESCRIPTION
- Moved mercenary-stats-display inside mercenary-section div
- Added flexbox to mercenary-section for proper vertical stacking
- Changed stats grid from 2 to 4 columns to better utilize space
- Removed margin-top from stats display (using flexbox gap instead)
- Stats now appear below equipment instead of at page bottom