### PR TITLE
Position mercenary stats display to the right of equipment

### DIFF
--- a/index.html
+++ b/index.html
@@ -554,7 +554,9 @@
              </div>
               </div>
 
-              <!-- Mercenary Stats Display -->
+              </div>
+
+              <!-- Mercenary Stats Display (positioned absolutely to the right) -->
               <div class="mercenary-stats-display">
                 <h4>Mercenary Stats</h4>
                 <div class="merc-stats-grid">
@@ -631,8 +633,6 @@
                     <span id="merc-curse-res" class="merc-stat-value">0</span>
                   </div>
                 </div>
-              </div>
-
               </div>
 
 

--- a/style.css
+++ b/style.css
@@ -383,9 +383,6 @@ body {
   border-radius: 10px;
   padding: 20px;
   height: fit-content;
-  display: flex;
-  flex-direction: column;
-  gap: 15px;
 }
 
 .mercequipment-container {
@@ -1052,11 +1049,15 @@ body.moody .stat-group h4 {
 
 /* Mercenary Stats Display */
 .mercenary-stats-display {
+  position: absolute;
+  left: 345vh;
+  top: 50px;
   padding: 15px;
   background: rgba(30, 30, 30, 0.8);
   border: 2px solid #8B4513;
   border-radius: 8px;
-  width: 100%;
+  width: 400px;
+  max-width: 500px;
 }
 
 .mercenary-stats-display h4 {
@@ -1070,7 +1071,7 @@ body.moody .stat-group h4 {
 
 .merc-stats-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(2, 1fr);
   gap: 8px;
 }
 


### PR DESCRIPTION
- Moved mercenary-stats-display outside of mercenary-section div
- Applied absolute positioning (left: 345vh) to place it to the right
- Stats now appear beside mercenary dropdowns, not below
- Changed grid from 4 to 2 columns for better readability with fixed width
- Matches player stats layout pattern (equipment left, stats right)