### PR TITLE
Check mercenary level requirements for mercenary items

### DIFF
--- a/main.js
+++ b/main.js
@@ -992,6 +992,11 @@ function setupMercLevelValidation() {
     }
 
     mercLevelInput.value = mercLevel;
+
+    // Recalculate mercenary stats when level changes
+    if (window.unifiedSocketSystem) {
+      window.unifiedSocketSystem.updateAll();
+    }
   });
 
   // Update mercenary max level when player level changes
@@ -1002,6 +1007,11 @@ function setupMercLevelValidation() {
     // If mercenary level exceeds new player level, cap it
     if (mercLevel > playerLevel) {
       mercLevelInput.value = playerLevel;
+
+      // Recalculate mercenary stats since level was capped
+      if (window.unifiedSocketSystem) {
+        window.unifiedSocketSystem.updateAll();
+      }
     }
   });
 }


### PR DESCRIPTION
- Mercenary items now check against mercenary level (merclvlValue) instead of player level
- Items that exceed mercenary level don't parse into mercenary stats counter
- Socket items also checked against mercenary level requirements
- Added TODO comment for future strength/dexterity requirement checks
- Stats recalculate automatically when mercenary level changes
- Mercenary stats only count items the mercenary can actually use