### PR TITLE
Fix socket corruption and URL sharing issues

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -1545,6 +1545,20 @@
     }
 
     // Set socket count to exact number (for corruption system)
+    getSocketCount(section) {
+      const container = document.querySelector(`.socket-container[data-section="${section}"]`);
+      if (!container) {
+        return 0;
+      }
+
+      const socketGrid = container.querySelector('.socket-grid');
+      if (!socketGrid) {
+        return 0;
+      }
+
+      return socketGrid.children.length;
+    }
+
     setSocketCount(section, targetCount) {
       const container = document.querySelector(`.socket-container[data-section="${section}"]`);
       if (!container) {


### PR DESCRIPTION
- Add getSocketCount method to UnifiedSocketSystem
- Fix socket slots persisting when changing from socket corruption to regular corruption
- Add corruption reapplication when loading builds from URL
- Restore socket counts properly for socket corruptions when loading builds