### PR TITLE
Fix missing All Skills bonus parsing in parseStatLine

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -3301,7 +3301,11 @@ if (defMatch) {
     
     const manaMatch = cleanLine.match(/(?:\+)?(\d+)\s+(?:to\s+)?Mana/i);
     if (manaMatch) { this.stats.mana += parseInt(manaMatch[1]); return; }
-    
+
+    // All Skills
+    const allSkillsMatch = cleanLine.match(/(?:\+)?(\d+)\s+(?:to\s+)?All\s+Skills/i);
+    if (allSkillsMatch) { this.stats.allSkills += parseInt(allSkillsMatch[1]); return; }
+
     // Resistances
     const allResMatch = cleanLine.match(/All\s+Resistances?\s+(?:\+)?(\d+)%?/i);
     if (allResMatch) {


### PR DESCRIPTION
The parseStatLine function was missing the handler for '+X to All Skills' bonus. This caused items like Stone of Jordan and Peasant Crown to not display their all skills bonus in the stat counter, even though the property existed in the data.

Added regex match for All Skills pattern and application to this.stats.allSkills