### PR TITLE
Revert skip logic - defense property must be processed to use calcula…

### DIFF
--- a/main.js
+++ b/main.js
@@ -528,11 +528,6 @@ window.generateItemDescription = function generateItemDescription(itemName, item
   // Skip certain properties that are metadata or handled elsewhere
   const skipProperties = ['javelin', 'speed', 'onehandmax', 'twohandmax', 'throwmax', 'smitedmgmax'];
 
-  // Skip static defense value if we're calculating defense dynamically from edef
-  if (props.edef && item.baseType && baseDefenseMap[item.baseType]) {
-    skipProperties.push('defense');
-  }
-
   // Iterate through propertyDisplay keys in order to control display order
   // This ensures damage lines appear in the correct position, not at the end
   for (const key of Object.keys(propertyDisplay)) {


### PR DESCRIPTION
…ted value

The defense property needs to be processed so that propertyDisplay['defense'] can check if defenseDisplay is set and use the calculated value instead of the static property value. The range optimization (only showing min-max when different) handles the display correctly.