### PR TITLE
Preserve dynamic stat values when switching items

### DIFF
--- a/main.js
+++ b/main.js
@@ -697,19 +697,6 @@ window.updateItemInfo = function updateItemInfo(event) {
   const item = itemList && itemList[selectedItemName];
 
   if (item) {
-    // Reset any .current values for dynamic items to ensure fresh regeneration
-    // This prevents values from "sticking" when switching between items
-    // BUT skip if we're loading a saved build (to preserve the saved values)
-    if (item.properties && item.baseType && !window._isLoadingCharacterData) {
-      Object.keys(item.properties).forEach(key => {
-        const prop = item.properties[key];
-        if (typeof prop === 'object' && prop !== null && 'max' in prop) {
-          // Reset to max value instead of deleting to avoid [object Object] display
-          prop.current = prop.max;
-        }
-      });
-    }
-
     // Generate description (handles both static and dynamic with variable stats)
     const description = generateItemDescription(selectedItemName, item, dropdown.id);
     infoDiv.innerHTML = description;


### PR DESCRIPTION
Remove the automatic reset logic that was resetting all dynamic stat values to max when switching items. Values now persist on the item object, so when you set edmg to 46% on Arcanna's Deathwand and switch to another item, the 46% value will still be there when you switch back.

The values are only reset when loading a saved build (already handled by _isLoadingCharacterData flag).