### PR TITLE
Skip socket updateAll for dynamic items to prevent input focus issues

### DIFF
--- a/main.js
+++ b/main.js
@@ -630,7 +630,8 @@ function handleVariableStatChange(itemName, propKey, newValue, dropdownId, skipR
     }
 
     // Notify socket system to update with the new innerHTML
-    if (window.unifiedSocketSystem && typeof window.unifiedSocketSystem.updateAll === 'function') {
+    // (but skip for dynamic items to avoid re-regenerating and breaking input focus)
+    if (window.unifiedSocketSystem && typeof window.unifiedSocketSystem.updateAll === 'function' && item.description) {
       window.unifiedSocketSystem.updateAll();
     }
 


### PR DESCRIPTION
For dynamic items (no static description), skip calling unifiedSocketSystem.updateAll() when handling variable stat changes. This prevents the socket system from regenerating the description while the user is typing, which was breaking input focus and preventing input on items like Arcanna's Deathwand.

Static description items still call updateAll for proper socket integration.