### PR TITLE
Fix input focus loss on dynamic items with variable stats

### DIFF
--- a/main.js
+++ b/main.js
@@ -602,6 +602,14 @@ function handleVariableStatChange(itemName, propKey, newValue, dropdownId, skipR
       if (infoDivId) {
         const infoDiv = document.getElementById(infoDivId);
         if (infoDiv) {
+          // Save focus state before regenerating
+          const activeElement = document.activeElement;
+          const isFocusedInput = activeElement &&
+                                 activeElement.classList.contains('stat-input') &&
+                                 activeElement.dataset.item === itemName &&
+                                 activeElement.dataset.prop === propKey;
+          const cursorPosition = isFocusedInput ? activeElement.selectionStart : null;
+
           let description = generateItemDescription(itemName, item, dropdownId);
 
           // If item has corruption, we need to reapply it to the regenerated description
@@ -621,6 +629,17 @@ function handleVariableStatChange(itemName, propKey, newValue, dropdownId, skipR
 
           // Re-attach event listeners to the new input boxes
           attachStatInputListeners();
+
+          // Restore focus and cursor position if we were focused on this input
+          if (isFocusedInput) {
+            const newInput = infoDiv.querySelector(`.stat-input[data-item="${itemName}"][data-prop="${propKey}"]`);
+            if (newInput) {
+              newInput.focus();
+              if (cursorPosition !== null) {
+                newInput.setSelectionRange(cursorPosition, cursorPosition);
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
When typing in input boxes for dynamic items like Arcanna's Deathwand, the handleVariableStatChange function was regenerating the entire description HTML, which destroyed and recreated the input element, causing focus and cursor position to be lost.

This fix:
- Saves the active element and cursor position before regenerating description
- Regenerates the description as before
- Restores focus and cursor position to the corresponding new input element

This allows users to type values into dynamic stat input boxes without losing focus after each keystroke.