### PR TITLE
Fix corruptions/upgrades breaking on dynamic items

### DIFF
--- a/main.js
+++ b/main.js
@@ -703,7 +703,22 @@ window.updateItemInfo = function updateItemInfo(event) {
   const item = itemList && itemList[selectedItemName];
 
   if (item) {
-    // Generate description (handles both static and dynamic with variable stats)
+    // For dynamic items (no static description), delegate to socket system
+    // This ensures proper handling of corruptions, upgrades, and socket stats
+    if (!item.description && window.unifiedSocketSystem) {
+      const section = window.SECTION_MAP && window.SECTION_MAP[dropdown.id];
+      if (section) {
+        // Adjust socket count for new item if needed
+        if (typeof window.unifiedSocketSystem.adjustSocketsForItem === 'function') {
+          window.unifiedSocketSystem.adjustSocketsForItem(section);
+        }
+        // Update display with full socket system integration
+        window.unifiedSocketSystem.updateItemDisplay(section);
+        return; // Socket system handles everything for dynamic items
+      }
+    }
+
+    // For static items, generate description normally
     const description = generateItemDescription(selectedItemName, item, dropdown.id);
     infoDiv.innerHTML = description;
 
@@ -714,7 +729,7 @@ window.updateItemInfo = function updateItemInfo(event) {
     infoDiv.innerHTML = selectedItemName;
   }
 
-  // Adjust socket count for new item if needed, then update socket system
+  // For static items, adjust socket count and update socket system
   const section = window.SECTION_MAP && window.SECTION_MAP[dropdown.id];
   if (section && window.unifiedSocketSystem) {
     try {

--- a/socket.js
+++ b/socket.js
@@ -2462,7 +2462,16 @@ this.selectedJewelSuffix3MaxValue = null;
     if (!item.description) {
       // Always regenerate description for dynamic items to re-attach event listeners
       // (This is critical for items like Arcanna's Deathwand with variable stats)
-      const baseDescription = window.generateItemDescription(dropdown.value, item, dropdownId);
+      let baseDescription = window.generateItemDescription(dropdown.value, item, dropdownId);
+
+      // Check if item has corruption applied
+      if (window.itemCorruptions && window.itemCorruptions[dropdownId]) {
+        const corruption = window.itemCorruptions[dropdownId];
+        if (corruption.text && typeof window.addCorruptionWithStacking === 'function') {
+          // Apply corruption to the dynamically generated description
+          baseDescription = window.addCorruptionWithStacking(baseDescription, corruption.text);
+        }
+      }
 
       // Parse base stats from the generated description (strip input elements first)
       const tempDiv = document.createElement('div');


### PR DESCRIPTION
When upgrading or corrupting dynamic items like True Silver or String of Ears:
1. Input boxes would become locked/non-functional
2. Items wouldn't upgrade properly
3. Corruptions would be lost after first display update

Root causes:
1. updateItemInfo was regenerating dynamic items from scratch (losing corruptions)
2. socket.updateItemDisplay didn't check for corruptions on dynamic items
3. Double regeneration caused input listeners to break

The fix:
- updateItemInfo now delegates to socket system for ALL dynamic items
- socket.updateItemDisplay checks for corruptions via window.itemCorruptions
- Applies corruptions using addCorruptionWithStacking before socket stats
- Single code path ensures consistency (no double regeneration)

Now works correctly:
- True Silver: Upgrade works, input boxes stay functional
- String of Ears: Upgrade works, variable stats preserved
- All dynamic items: Corruptions persist through all updates
- Input boxes: Always functional after corruption/upgrade