### PR TITLE
Fix calculateItemDefense crash for dynamic items (String of Ears, etc)

### DIFF
--- a/itemUpgrade.js
+++ b/itemUpgrade.js
@@ -2907,7 +2907,7 @@ function buildDescriptionWeapon(itemName, baseType, properties, magicalProps) {
 function calculateItemDefense(item, baseType, category = "helm") {
   const baseDefense = baseDefenses[baseType] || 0;
   const { edef, todef } = item.properties || {};
-  const ethMult = item.description.includes("Ethereal") ? 1.5 : 1;
+  const ethMult = item.description && item.description.includes("Ethereal") ? 1.5 : 1;
 
   let socketsEDef = 0;
   document


### PR DESCRIPTION
calculateItemDefense was trying to access item.description.includes('Ethereal') but dynamic items don't have a description property, causing TypeError.

Fixed by adding null check:
  const ethMult = item.description && item.description.includes('Ethereal') ? 1.5 : 1;

This allows dynamic items like String of Ears to upgrade without crashing. calculateItemDamage already had this check, so weapons were fine.