### PR TITLE
Fix True Silver input boxes by preventing updateWeaponDamageDisplay f…

### DIFF
--- a/itemUpgrade.js
+++ b/itemUpgrade.js
@@ -4427,19 +4427,24 @@ function updateWeaponDamageDisplay() {
       }
     }
 
-    // Now regenerate description for dynamic items after damage is calculated
-    // This ensures damage lines are included in the generated description
+    // For dynamic items, let the socket system handle the display
+    // (Don't set description property or call updateWeaponTooltip - that would destroy input boxes!)
     if (isDynamic) {
-      description = window.generateItemDescription(currentItem, currentItemData, 'weapons-dropdown');
-      currentItemData.description = description;
-    }
+      // Just trigger a display update via socket system
+      if (window.unifiedSocketSystem && window.unifiedSocketSystem.equipmentMap) {
+        const config = window.unifiedSocketSystem.equipmentMap['weapons-dropdown'];
+        if (config && config.section) {
+          window.unifiedSocketSystem.updateItemDisplay(config.section);
+        }
+      }
+    } else {
+      // For static items, update the tooltip normally
+      updateWeaponTooltip(currentItemData, baseType, isTwoHanded);
 
-    // Update the tooltip/description
-    updateWeaponTooltip(currentItemData, baseType, isTwoHanded);
-
-    // Re-attach event listeners to stat input boxes in the weapon info
-    if (typeof window.attachStatInputListeners === 'function') {
-      window.attachStatInputListeners();
+      // Re-attach event listeners to stat input boxes in the weapon info
+      if (typeof window.attachStatInputListeners === 'function') {
+        window.attachStatInputListeners();
+      }
     }
   }
 }


### PR DESCRIPTION
…rom converting dynamic items to static

The issue was in updateWeaponDamageDisplay (itemUpgrade.js:4430-4448):
- It was setting currentItemData.description for dynamic items
- This converted them from dynamic to static
- Then updateWeaponTooltip directly set innerHTML, destroying input boxes

Now for dynamic items:
- Skip setting description property
- Skip calling updateWeaponTooltip
- Delegate to socket system's updateItemDisplay instead
- This preserves input boxes and event listeners

Only static items use the old updateWeaponTooltip approach.