### PR TITLE
Fix DR/PDR/MDR parsing for mercenary stats and item descriptions

### DIFF
--- a/main.js
+++ b/main.js
@@ -525,7 +525,7 @@ window.generateItemDescription = function generateItemDescription(itemName, item
     ligres: (val, prop) => formatVariableStat('+', val, '% Lightning Resistance', prop, itemName, 'ligres', dropdownId),
     curseres: (val, prop) => formatVariableStat('+', val, '% Curse Resistance', prop, itemName, 'curseres', dropdownId),
     physdr: (val, prop) => formatVariableStat('Physical Damage Taken Reduced by ', val, '%', prop, itemName, 'physdr', dropdownId),
-    mdr: (val, prop) => formatVariableStat('Magic Damage Taken Reduced by ', val, '%', prop, itemName, 'mdr', dropdownId),
+    mdr: (val, prop) => formatVariableStat('Magic Damage Reduced by ', val, '', prop, itemName, 'mdr', dropdownId),
   };
 
   // Build description from properties

--- a/socket.js
+++ b/socket.js
@@ -3064,19 +3064,22 @@ this.selectedJewelSuffix3MaxValue = null;
         }
 
         // Damage Reduction stats
-        const drMatch = cleanLine.match(/Damage\s+(?:Taken\s+)?Reduced\s+by\s+(\d+)%?/i);
-        if (drMatch) {
-          this.mercenaryStats.dr += parseInt(drMatch[1]);
-          return;
-        }
-
-        const pdrMatch = cleanLine.match(/Physical\s+Damage\s+(?:Taken\s+)?Reduced\s+by\s+(\d+)%?/i);
+        // Physical Damage Taken Reduced by X (flat -> PDR)
+        const pdrMatch = cleanLine.match(/Physical\s+Damage\s+(?:Taken\s+)?Reduced\s+by\s+(\d+)(?!%)/i);
         if (pdrMatch) {
           this.mercenaryStats.pdr += parseInt(pdrMatch[1]);
           return;
         }
 
-        const mdrMatch = cleanLine.match(/Magic\s+Damage\s+(?:Taken\s+)?Reduced\s+by\s+(\d+)%?/i);
+        // Physical Damage Reduced by X% (percentage -> DR)
+        const drMatch = cleanLine.match(/(?:Physical\s+)?Damage\s+(?:Taken\s+)?Reduced\s+by\s+(\d+)%/i);
+        if (drMatch) {
+          this.mercenaryStats.dr += parseInt(drMatch[1]);
+          return;
+        }
+
+        // Magic Damage Reduced by X (flat -> MDR)
+        const mdrMatch = cleanLine.match(/Magic\s+Damage\s+(?:Taken\s+)?Reduced\s+by\s+(\d+)(?!%)/i);
         if (mdrMatch) {
           this.mercenaryStats.mdr += parseInt(mdrMatch[1]);
           return;


### PR DESCRIPTION
- Fixed mercenary stats regex patterns to properly distinguish flat vs percentage damage reduction:
  * PDR: Physical Damage Taken Reduced by X (flat, no %)
  * DR: Physical Damage Taken Reduced by X% (percentage only)
  * MDR: Magic Damage Reduced by X (flat, no %)
- Fixed String of Ears and other items MDR text to show "Magic Damage Reduced by X" without % symbol
- Changed text from "Magic Damage Taken Reduced by" to "Magic Damage Reduced by" to match game text