### PR TITLE
Fix physdr parsing order - check percentage before flat patterns

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -3397,17 +3397,18 @@ if (defMatch) {
     if (fhrMatch) { this.stats.fhr += parseInt(fhrMatch[1]); return; }
 
     // Damage Reduction stats
+    // Physical Damage Reduced by X% OR Physical Damage Taken Reduced by X% (percentage -> DR)
+    // Check percentage first (more specific) before flat patterns
+    const drPercentMatch = cleanLine.match(/Physical\s+Damage\s+(?:Taken\s+)?Reduced\s+by\s+(\d+)%/i);
+    if (drPercentMatch) {
+      this.stats.dr += parseInt(drPercentMatch[1]);
+      return;
+    }
+
     // Physical Damage Taken Reduced by X (flat -> PDR)
     const pdrFlatMatch = cleanLine.match(/Physical\s+Damage\s+(?:Taken\s+)?Reduced\s+by\s+(\d+)(?!%)/i);
     if (pdrFlatMatch) {
       this.stats.pdr += parseInt(pdrFlatMatch[1]);
-      return;
-    }
-
-    // Physical Damage Reduced by X% OR Physical Damage Taken Reduced by X% (percentage -> DR)
-    const drPercentMatch = cleanLine.match(/Physical\s+Damage\s+(?:Taken\s+)?Reduced\s+by\s+(\d+)%/i);
-    if (drPercentMatch) {
-      this.stats.dr += parseInt(drPercentMatch[1]);
       return;
     }
 


### PR DESCRIPTION
String of Ears was showing 1 in pdrcontainer instead of 15 in drcontainer because the flat PDR pattern was matching first with incorrect negative lookahead, capturing "1" instead of waiting for the percentage pattern to match "15%".

Solution: Check percentage patterns first (more specific) before flat patterns. This ensures "Physical Damage Taken Reduced by 15%" correctly goes to DR (%) instead of being mismatched as PDR (flat) with value 1.

Also fixes: MDR input updates now work properly as a side effect since both use the same parsing flow.