### PR TITLE
Add immediate defensive stat updates for variable item properties

### DIFF
--- a/main.js
+++ b/main.js
@@ -663,6 +663,18 @@ function handleVariableStatChange(itemName, propKey, newValue, dropdownId, skipR
     if (dropdownId === 'weapons-dropdown' && typeof window.updateWeaponDamageDisplay === 'function') {
       window.updateWeaponDamageDisplay();
     }
+
+    // For properties that affect defensive stats, recalculate and update the stat display
+    // This ensures drcontainer, mdrcontainer, pdrcontainer, etc. update immediately
+    const defensiveStatProps = ['physdr', 'mdr', 'pdr', 'dr', 'plr', 'frw', 'fhr', 'cb', 'ow', 'deadly'];
+    if (defensiveStatProps.includes(propKey) && window.unifiedSocketSystem) {
+      if (typeof window.unifiedSocketSystem.calculateAllStats === 'function') {
+        window.unifiedSocketSystem.calculateAllStats();
+      }
+      if (typeof window.unifiedSocketSystem.updateStatsDisplay === 'function') {
+        window.unifiedSocketSystem.updateStatsDisplay();
+      }
+    }
   }
 }
 


### PR DESCRIPTION
When changing physdr/mdr/pdr/dr or other defensive stats on dynamic items, the item description now updates immediately AND the character stat totals (drcontainer, mdrcontainer, pdrcontainer, etc.) now also update immediately without needing to change level/str/dex/enr.

This works by calling calculateAllStats() and updateStatsDisplay() after updating the item property, which recalculates all stats and refreshes the defensive stat display containers.

Fixes the issue where String of Ears physdr/mdr values would show updated in the item description but not update in the character total stats display.