### PR TITLE
Add simple crafted items system

### DIFF
--- a/auth-ui.js
+++ b/auth-ui.js
@@ -140,6 +140,10 @@ function setupAuthListeners() {
             updateProfileButton();
             showLoggedInView();
             errorEl.textContent = '';
+            // Refresh item dropdowns to show crafted items
+            if (typeof refreshItemDropdowns === 'function') {
+                refreshItemDropdowns();
+            }
         } else {
             errorEl.textContent = result.error;
         }
@@ -172,6 +176,10 @@ function setupAuthListeners() {
             updateProfileButton();
             showLoggedInView();
             errorEl.textContent = '';
+            // Refresh item dropdowns to show crafted items
+            if (typeof refreshItemDropdowns === 'function') {
+                refreshItemDropdowns();
+            }
         } else {
             errorEl.textContent = result.error;
         }

--- a/character-data.js
+++ b/character-data.js
@@ -119,7 +119,8 @@ window.exportCharacterData = function() {
         poison: parseInt(document.getElementById('poisonresistcontainer')?.textContent) || 0
     };
 
-   
+    // Get crafted items if available
+    const craftedItems = window.craftedItemsSystem ? window.craftedItemsSystem.exportToData() : [];
 
     return {
         version: '1.1',
@@ -141,7 +142,8 @@ window.exportCharacterData = function() {
         variableStats,
         charms,
         skills,
-        resistances
+        resistances,
+        crafted_items: craftedItems
     };
 };
 
@@ -235,6 +237,11 @@ window.loadCharacterFromData = function(data) {
                 }
             }
             
+        }
+
+        // Load crafted items
+        if (data.crafted_items && window.craftedItemsSystem) {
+            window.craftedItemsSystem.loadFromData(data.crafted_items);
         }
 
         // Set equipment

--- a/craftedItems.js
+++ b/craftedItems.js
@@ -1,0 +1,178 @@
+// Crafted Items System
+// Manages creation, storage, and retrieval of player-crafted items
+
+class CraftedItemsSystem {
+  constructor() {
+    this.craftedItems = []; // Array of crafted items
+    this.nextId = 1;
+
+    // Craft types with their benefits
+    this.craftTypes = {
+      blood: 'Blood Craft',
+      caster: 'Caster Craft',
+      hitpower: 'Hit Power Craft',
+      safety: 'Safety Craft',
+      vampiric: 'Vampiric Craft',
+      bountiful: 'Bountiful Craft',
+      brilliant: 'Brilliant Craft'
+    };
+
+    // Possible affixes that can spawn on crafted items (with value ranges)
+    this.affixesPool = {
+      // Combat
+      enhancedDamage: { min: 50, max: 80, label: 'Enhanced Damage' },
+      lifeSteal: { min: 3, max: 6, label: 'Life Steal %' },
+      attackRating: { min: 50, max: 150, label: 'Attack Rating' },
+
+      // Defense
+      enhancedDefense: { min: 25, max: 50, label: 'Enhanced Defense' },
+      blockChance: { min: 10, max: 20, label: 'Block Chance %' },
+
+      // Stats
+      strength: { min: 5, max: 10, label: '+Strength' },
+      dexterity: { min: 5, max: 10, label: '+Dexterity' },
+      vitality: { min: 5, max: 10, label: '+Vitality' },
+      energy: { min: 5, max: 10, label: '+Energy' },
+
+      // Resistances
+      allResist: { min: 5, max: 10, label: 'All Resistances' },
+      fireResist: { min: 10, max: 20, label: 'Fire Resist' },
+      coldResist: { min: 10, max: 20, label: 'Cold Resist' },
+      lightningResist: { min: 10, max: 20, label: 'Lightning Resist' },
+      poisonResist: { min: 10, max: 20, label: 'Poison Resist' },
+
+      // Utility
+      magicFind: { min: 10, max: 20, label: 'Magic Find %' },
+      goldFind: { min: 10, max: 20, label: 'Gold Find %' },
+      fastCastRate: { min: 10, max: 20, label: 'FCR' },
+      fasterHitRecovery: { min: 10, max: 20, label: 'FHR' },
+      fasterRunWalk: { min: 5, max: 10, label: 'FRW %' },
+      increasedAttackSpeed: { min: 5, max: 10, label: 'IAS %' },
+
+      // Life/Mana
+      life: { min: 10, max: 30, label: '+Life' },
+      mana: { min: 10, max: 30, label: '+Mana' },
+
+      // Special
+      allSkills: { min: 1, max: 3, label: '+All Skills' },
+      curseResist: { min: 10, max: 20, label: 'Curse Resist' }
+    };
+  }
+
+  /**
+   * Create a new crafted item
+   * @param {string} name - Item name (up to 11 chars, alphanumeric + space)
+   * @param {string} baseType - Base item type (e.g., "War Pike", "Archon Plate")
+   * @param {string} craftType - Craft type (blood, caster, hitpower, safety, vampiric, bountiful, brilliant)
+   * @param {Object} affixes - Selected affixes with their values {affixKey: value}
+   * @returns {Object} Created crafted item or null if validation fails
+   */
+  createCraftedItem(name, baseType, craftType, affixes = {}) {
+    // Validate name
+    if (!name || name.length > 11) {
+      console.error('Crafted item name must be 1-11 characters');
+      return null;
+    }
+    if (!/^[a-zA-Z0-9 ]+$/.test(name)) {
+      console.error('Crafted item name can only contain letters, numbers, and spaces');
+      return null;
+    }
+
+    // Validate base type exists
+    if (!baseType || typeof itemList === 'undefined' || !itemList[baseType]) {
+      console.error(`Invalid base item type: ${baseType}`);
+      return null;
+    }
+
+    // Validate craft type
+    if (!this.craftTypes[craftType]) {
+      console.error(`Invalid craft type: ${craftType}`);
+      return null;
+    }
+
+    // Get base item to determine category
+    const baseItem = itemList[baseType];
+    const itemType = detectItemType(baseType, baseItem);
+
+    // Create crafted item
+    const craftedItem = {
+      id: `craft_${this.nextId++}`,
+      name: name,
+      baseType: baseType,
+      fullName: `${name} ${baseType}`, // Display name
+      craftType: craftType,
+      craftTypeLabel: this.craftTypes[craftType],
+      itemType: itemType, // For dropdown categorization
+      affixes: { ...affixes }, // Copy affixes object
+      createdAt: new Date().toISOString()
+    };
+
+    this.craftedItems.push(craftedItem);
+    return craftedItem;
+  }
+
+  /**
+   * Get all crafted items of a specific type (weapon, armor, etc.)
+   * @param {string} itemType - Item type (weapon, helm, armor, etc.)
+   * @returns {Array} Array of crafted items for that type
+   */
+  getCraftedItemsByType(itemType) {
+    return this.craftedItems.filter(item => item.itemType === itemType);
+  }
+
+  /**
+   * Get all crafted items
+   * @returns {Array} All crafted items
+   */
+  getAllCraftedItems() {
+    return [...this.craftedItems];
+  }
+
+  /**
+   * Delete a crafted item by ID
+   * @param {string} id - Crafted item ID
+   * @returns {boolean} True if deleted, false if not found
+   */
+  deleteCraftedItem(id) {
+    const index = this.craftedItems.findIndex(item => item.id === id);
+    if (index !== -1) {
+      this.craftedItems.splice(index, 1);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Load crafted items from saved data
+   * @param {Array} data - Array of crafted items from character_data.crafted_items
+   */
+  loadFromData(data) {
+    if (!Array.isArray(data)) return;
+
+    this.craftedItems = [...data];
+    // Update nextId to ensure no conflicts
+    if (data.length > 0) {
+      const maxId = Math.max(...data.map(item => parseInt(item.id.split('_')[1]) || 0));
+      this.nextId = maxId + 1;
+    }
+  }
+
+  /**
+   * Export crafted items for saving
+   * @returns {Array} Serialized crafted items
+   */
+  exportToData() {
+    return JSON.parse(JSON.stringify(this.craftedItems));
+  }
+
+  /**
+   * Clear all crafted items
+   */
+  clear() {
+    this.craftedItems = [];
+    this.nextId = 1;
+  }
+}
+
+// Initialize global crafted items system
+window.craftedItemsSystem = new CraftedItemsSystem();

--- a/index.html
+++ b/index.html
@@ -687,9 +687,57 @@
 
 
 
-   
+
+
+        <!-- Crafting Modal -->
+        <div id="craftingModal" class="modal" style="display: none;">
+            <div class="modal-content">
+                <span class="modal-close" onclick="closeCraftingModal()">&times;</span>
+                <h2>Create Crafted Item</h2>
+
+                <div class="craft-form">
+                    <div class="form-group">
+                        <label for="craftName">Item Name (max 11 chars):</label>
+                        <input type="text" id="craftName" maxlength="11" placeholder="e.g. myTestWeapon">
+                    </div>
+
+                    <div class="form-group">
+                        <label for="craftBaseType">Base Item Type:</label>
+                        <select id="craftBaseType">
+                            <option value="">Select base item...</option>
+                        </select>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="craftType">Craft Type:</label>
+                        <select id="craftType">
+                            <option value="blood">Blood Craft</option>
+                            <option value="caster">Caster Craft</option>
+                            <option value="hitpower">Hit Power Craft</option>
+                            <option value="safety">Safety Craft</option>
+                            <option value="vampiric">Vampiric Craft</option>
+                            <option value="bountiful">Bountiful Craft</option>
+                            <option value="brilliant">Brilliant Craft</option>
+                        </select>
+                    </div>
+
+                    <div class="form-group">
+                        <label>Affixes (adjust sliders):</label>
+                        <div id="affixesContainer" class="affixes-grid">
+                            <!-- Dynamically populated -->
+                        </div>
+                    </div>
+
+                    <div class="form-actions">
+                        <button onclick="createCraftedItem()">Create Crafted Item</button>
+                        <button onclick="closeCraftingModal()" class="cancel-btn">Cancel</button>
+                    </div>
+                </div>
+            </div>
+        </div>
 
 <script src="items.js"></script>
+<script src="craftedItems.js"></script>
 <script src="character.js"></script>
 <script src="socket.js"></script>
 <script src="corrupt.js"></script>


### PR DESCRIPTION
- Create craftedItems.js with CraftedItemsSystem class for managing player-crafted items
- Store crafted items in character_data.crafted_items array (no DB changes needed)
- Add crafting modal UI with base item selector and affix sliders (7 craft types)
- Modify main.js to display crafted items in dropdowns (only when logged in)
- Add "Craft Item" button below "Save Build" button
- Hook into login/register to refresh dropdowns with crafted items
- Crafted items cleared automatically on logout (page reload)
- Crafted items persist in shared URLs since they're in character_data
- Minimal changes to existing systems, no breaking changes