### PR TITLE
Polish crafting modal UI to be prominent and always visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -690,27 +690,30 @@
 
 
         <!-- Crafting Modal -->
-        <div id="craftingModal" class="modal" style="display: none;">
-            <div class="modal-content">
-                <span class="modal-close" onclick="closeCraftingModal()">&times;</span>
-                <h2>Create Crafted Item</h2>
+        <div id="craftingModalBackdrop" style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0, 0, 0, 0.7); z-index: 9998;"></div>
+        <div id="craftingModal" style="display: none; position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 9999; max-height: 90vh; overflow-y: auto; width: 90%; max-width: 600px;">
+            <div style="background: linear-gradient(135deg, #1a1a2e, #16213e); border: 2px solid #0f3460; border-radius: 8px; padding: 25px; box-shadow: 0 0 40px rgba(15, 52, 96, 0.8), inset 0 0 20px rgba(0, 0, 0, 0.5);">
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
+                    <h2 style="color: #ffd700; margin: 0; font-size: 24px; text-shadow: 0 0 10px rgba(255, 215, 0, 0.5);">⚒️ CREATE CRAFTED ITEM</h2>
+                    <button onclick="closeCraftingModal()" style="background: #e74c3c; border: none; color: white; font-size: 28px; cursor: pointer; width: 40px; height: 40px; border-radius: 50%; padding: 0; display: flex; align-items: center; justify-content: center; transition: all 0.3s ease;" onmouseover="this.style.background='#c0392b'; this.style.boxShadow='0 0 20px rgba(231, 76, 60, 0.8)';" onmouseout="this.style.background='#e74c3c'; this.style.boxShadow='none';">×</button>
+                </div>
 
                 <div class="craft-form">
-                    <div class="form-group">
-                        <label for="craftName">Item Name (max 11 chars):</label>
-                        <input type="text" id="craftName" maxlength="11" placeholder="e.g. myTestWeapon">
+                    <div class="form-group" style="margin-bottom: 15px;">
+                        <label for="craftName" style="display: block; color: #ffd700; font-weight: bold; margin-bottom: 8px; text-shadow: 0 0 5px rgba(255, 215, 0, 0.3);">Item Name (max 11 chars):</label>
+                        <input type="text" id="craftName" maxlength="11" placeholder="e.g. myTestWeapon" style="width: 100%; padding: 10px; background: #0f3460; border: 1px solid #0f9eff; color: #ffd700; border-radius: 4px; font-size: 14px; box-sizing: border-box;">
                     </div>
 
-                    <div class="form-group">
-                        <label for="craftBaseType">Base Item Type:</label>
-                        <select id="craftBaseType">
+                    <div class="form-group" style="margin-bottom: 15px;">
+                        <label for="craftBaseType" style="display: block; color: #ffd700; font-weight: bold; margin-bottom: 8px; text-shadow: 0 0 5px rgba(255, 215, 0, 0.3);">Base Item Type:</label>
+                        <select id="craftBaseType" style="width: 100%; padding: 10px; background: #0f3460; border: 1px solid #0f9eff; color: #ffd700; border-radius: 4px; font-size: 14px; box-sizing: border-box;">
                             <option value="">Select base item...</option>
                         </select>
                     </div>
 
-                    <div class="form-group">
-                        <label for="craftType">Craft Type:</label>
-                        <select id="craftType">
+                    <div class="form-group" style="margin-bottom: 15px;">
+                        <label for="craftType" style="display: block; color: #ffd700; font-weight: bold; margin-bottom: 8px; text-shadow: 0 0 5px rgba(255, 215, 0, 0.3);">Craft Type:</label>
+                        <select id="craftType" style="width: 100%; padding: 10px; background: #0f3460; border: 1px solid #0f9eff; color: #ffd700; border-radius: 4px; font-size: 14px; box-sizing: border-box;">
                             <option value="blood">Blood Craft</option>
                             <option value="caster">Caster Craft</option>
                             <option value="hitpower">Hit Power Craft</option>
@@ -721,16 +724,16 @@
                         </select>
                     </div>
 
-                    <div class="form-group">
-                        <label>Affixes (adjust sliders):</label>
-                        <div id="affixesContainer" class="affixes-grid">
+                    <div class="form-group" style="margin-bottom: 15px;">
+                        <label style="display: block; color: #ffd700; font-weight: bold; margin-bottom: 8px; text-shadow: 0 0 5px rgba(255, 215, 0, 0.3);">Affixes (adjust sliders):</label>
+                        <div id="affixesContainer" class="affixes-grid" style="max-height: 300px; overflow-y: auto; padding: 10px; background: rgba(0, 0, 0, 0.3); border-radius: 4px; border: 1px solid #0f9eff;">
                             <!-- Dynamically populated -->
                         </div>
                     </div>
 
-                    <div class="form-actions">
-                        <button onclick="createCraftedItem()">Create Crafted Item</button>
-                        <button onclick="closeCraftingModal()" class="cancel-btn">Cancel</button>
+                    <div class="form-actions" style="display: flex; gap: 10px; margin-top: 20px;">
+                        <button onclick="createCraftedItem()" style="flex: 1; padding: 12px; background: linear-gradient(135deg, #28a745, #1e7e34); border: 1px solid #0f9eff; color: #ffd700; font-weight: bold; border-radius: 4px; cursor: pointer; font-size: 14px; transition: all 0.3s ease; box-shadow: 0 0 15px rgba(40, 167, 69, 0.4);" onmouseover="this.style.background='linear-gradient(135deg, #2ce84b, #22963d)'; this.style.boxShadow='0 0 25px rgba(44, 232, 75, 0.6)';" onmouseout="this.style.background='linear-gradient(135deg, #28a745, #1e7e34)'; this.style.boxShadow='0 0 15px rgba(40, 167, 69, 0.4)';">CREATE ITEM</button>
+                        <button onclick="closeCraftingModal()" style="flex: 1; padding: 12px; background: linear-gradient(135deg, #6c757d, #5a6268); border: 1px solid #0f9eff; color: #ffd700; font-weight: bold; border-radius: 4px; cursor: pointer; font-size: 14px; transition: all 0.3s ease; box-shadow: 0 0 15px rgba(108, 117, 125, 0.4);" onmouseover="this.style.background='linear-gradient(135deg, #7a8490, #6a7380)'; this.style.boxShadow='0 0 25px rgba(122, 132, 144, 0.6)';" onmouseout="this.style.background='linear-gradient(135deg, #6c757d, #5a6268)'; this.style.boxShadow='0 0 15px rgba(108, 117, 125, 0.4)';">CANCEL</button>
                     </div>
                 </div>
             </div>

--- a/main.js
+++ b/main.js
@@ -1024,25 +1024,34 @@ function openCraftingModal() {
       affixDiv.className = 'affix-control';
       affixDiv.style.cssText = `
         margin-bottom: 12px;
-        padding: 8px;
-        background: rgba(0,0,0,0.3);
+        padding: 10px;
+        background: rgba(15, 52, 96, 0.4);
+        border: 1px solid #0f9eff;
         border-radius: 4px;
       `;
 
       const label = document.createElement('label');
-      label.style.cssText = 'display: block; font-size: 12px; margin-bottom: 5px;';
-      label.innerHTML = `${affixData.label} <span id="val_${affixKey}">0</span>`;
+      label.style.cssText = 'display: block; font-size: 12px; margin-bottom: 8px; color: #ffd700; font-weight: bold; text-shadow: 0 0 3px rgba(255, 215, 0, 0.3);';
+      label.innerHTML = `${affixData.label} <span id="val_${affixKey}" style="color: #0f9eff; margin-left: 5px;">[${affixData.min}]</span>`;
 
       const slider = document.createElement('input');
       slider.type = 'range';
       slider.min = affixData.min;
       slider.max = affixData.max;
       slider.value = affixData.min;
-      slider.style.width = '100%';
+      slider.style.cssText = `
+        width: 100%;
+        height: 6px;
+        background: #0f3460;
+        border: 1px solid #0f9eff;
+        border-radius: 3px;
+        outline: none;
+        cursor: pointer;
+      `;
       slider.id = `affix_${affixKey}`;
 
       slider.addEventListener('input', (e) => {
-        document.getElementById(`val_${affixKey}`).textContent = e.target.value;
+        document.getElementById(`val_${affixKey}`).textContent = `[${e.target.value}]`;
       });
 
       affixDiv.appendChild(label);
@@ -1055,8 +1064,12 @@ function openCraftingModal() {
   document.getElementById('craftName').value = '';
   document.getElementById('craftType').value = 'blood';
 
-  // Show modal
+  // Show modal and backdrop
   modal.style.display = 'block';
+  const backdrop = document.getElementById('craftingModalBackdrop');
+  if (backdrop) {
+    backdrop.style.display = 'block';
+  }
 }
 
 /**
@@ -1064,8 +1077,12 @@ function openCraftingModal() {
  */
 function closeCraftingModal() {
   const modal = document.getElementById('craftingModal');
+  const backdrop = document.getElementById('craftingModalBackdrop');
   if (modal) {
     modal.style.display = 'none';
+  }
+  if (backdrop) {
+    backdrop.style.display = 'none';
   }
 }
 
@@ -1073,14 +1090,12 @@ function closeCraftingModal() {
  * Setup modal event listeners (click outside to close)
  */
 function setupCraftingModalHandlers() {
-  const modal = document.getElementById('craftingModal');
-  if (!modal) return;
+  const backdrop = document.getElementById('craftingModalBackdrop');
+  if (!backdrop) return;
 
-  // Close when clicking outside the modal
-  window.addEventListener('click', (event) => {
-    if (event.target === modal) {
-      closeCraftingModal();
-    }
+  // Close when clicking backdrop
+  backdrop.addEventListener('click', () => {
+    closeCraftingModal();
   });
 }
 


### PR DESCRIPTION
- Add dark backdrop with 70% opacity behind modal
- Change modal to fixed positioning (center of screen, follows scroll)
- Increase z-index to 9999 (on top of all other elements)
- Add gold title text with glow effect: "⚒️ CREATE CRAFTED ITEM"
- Style input fields with dark blue background (#0f3460) and cyan borders (#0f9eff)
- Color labels in gold (#ffd700) with subtle text shadow
- Add prominent red close button (circular, top right)
- Style buttons with gradients: green for CREATE, gray for CANCEL
- Add glow effects and hover animations to all interactive elements
- Update affix sliders with matching color scheme
- Show affix values in brackets with cyan color
- Make affixes container scrollable with max-height 300px
- Click backdrop to close modal