### PR TITLE
Fix crafted item description and duplicate checking

### DIFF
--- a/craftedItems.js
+++ b/craftedItems.js
@@ -123,6 +123,47 @@ class CraftedItemsSystem {
 
     // Create crafted item as a complete item object
     const fullName = `${name} ${baseType}`;
+
+    // Build description dynamically
+    let description = `<span style="color: #ffd700; font-weight: bold;">${fullName}</span><br>`;
+    description += `<span style="color: #8888ff;">${craftConfig.label}</span><br>`;
+    description += `${baseType}<br>`;
+
+    // Base properties
+    if (baseProperties.damage) {
+      description += `Damage: ${baseProperties.damage.min}-${baseProperties.damage.max}<br>`;
+    }
+    if (baseProperties.reqstr) {
+      description += `Required Strength: ${baseProperties.reqstr}<br>`;
+    }
+    description += '<br>';
+
+    // Fixed properties (from craft type)
+    for (const [propName, propData] of Object.entries(fixedProperties)) {
+      const sign = propData.value > 0 ? '+' : '';
+      const suffix = propData.type === 'percentage' ? '%' : '';
+      description += `<span style="color: #0f9eff;">${sign}${propData.value}${suffix} ${propName}</span><br>`;
+    }
+
+    // Prefixes
+    if (affixes.prefixes && Object.keys(affixes.prefixes).length > 0) {
+      for (const [affixKey, affixValue] of Object.entries(affixes.prefixes)) {
+        const affixDef = this.affixesPool.prefixes[affixKey];
+        if (affixDef) {
+          description += `<span style="color: #8888ff;">${affixDef.label.replace('+', '')}: ${affixValue}</span><br>`;
+        }
+      }
+    }
+
+    // Suffixes
+    if (affixes.suffixes && Object.keys(affixes.suffixes).length > 0) {
+      for (const [affixKey, affixValue] of Object.entries(affixes.suffixes)) {
+        const affixDef = this.affixesPool.suffixes[affixKey];
+        if (affixDef) {
+          description += `<span style="color: #8888ff;">${affixDef.label.replace('+', '')}: ${affixValue}</span><br>`;
+        }
+      }
+    }
     const craftedItem = {
       id: `craft_${this.nextId++}`,
       name: name, // Short name (e.g. "myTestWeapon")
@@ -136,7 +177,7 @@ class CraftedItemsSystem {
       baseProperties: baseProperties, // Base weapon properties (damage, requirements)
       fixedProperties: fixedProperties, // Fixed craft properties
       affixes: affixes, // Selected affixes with their values
-      description: '', // Will be built dynamically
+      description: description, // Dynamically built description
       createdAt: new Date().toISOString()
     };
 

--- a/main.js
+++ b/main.js
@@ -1516,4 +1516,20 @@ document.addEventListener('DOMContentLoaded', () => {
   if (username && typeof updateUIState === 'function') {
     updateUIState(username);
   }
+
+  // 12. Load crafted items if user is already logged in
+  setTimeout(async () => {
+    if (window.auth?.isLoggedIn() && window.craftedItemsSystem) {
+      try {
+        const craftedItems = await window.auth.getCraftedItems();
+        window.craftedItemsSystem.loadFromData(craftedItems);
+        // Refresh dropdowns to show crafted items
+        if (typeof populateItemDropdowns === 'function') {
+          populateItemDropdowns();
+        }
+      } catch (error) {
+        console.error('Failed to load crafted items on page load:', error);
+      }
+    }
+  }, 800);
 });

--- a/workers.js
+++ b/workers.js
@@ -167,19 +167,22 @@ async function getCraftedItems(sql, userId) {
 async function createCraftedItem(request, sql, userId) {
   try {
     const itemData = await request.json();
-    if (!itemData?.id || !itemData?.fullName) { // Use optional chaining
+    if (!itemData?.id || !itemData?.fullName) {
       return new Response(JSON.stringify({ error: 'Invalid item data' }), {
         status: 400,
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       });
     }
 
+    // Check if user already has an item with this name (simpler check)
     const existing = await sql`
-      SELECT id FROM crafted_items WHERE craft_id = ${itemData.id}
+      SELECT id FROM crafted_items
+      WHERE user_id = ${userId}
+      AND item_data->>'fullName' = ${itemData.fullName}
     `;
 
     if (existing.length > 0) {
-      return new Response(JSON.stringify({ error: 'Item already exists' }), {
+      return new Response(JSON.stringify({ error: 'You already have an item with this name' }), {
         status: 409,
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       });


### PR DESCRIPTION
1. Dynamic description building:
   - Shows item name, craft type, and base type
   - Displays base damage and strength requirement
   - Shows fixed properties from craft type (colored blue)
   - Lists all selected prefixes and suffixes (colored purple)
   - Now displays properly in weapon-info boxes

2. Simplified duplicate checking:
   - Changed from checking craft_id to user_id + fullName
   - Each user has their own namespace for item names
   - Can't create duplicate names (keeps dropdowns clean)
   - Different users can have same item names (no conflicts)
   - One simple query per check, minimal API calls

3. Load crafted items on page load:
   - Loads existing items from backend on initial page load
   - Updates nextId counter to prevent ID conflicts
   - Only loads if user is already logged in
   - Refreshes dropdowns to show items