### PR TITLE
Fix crafted item description display

### DIFF
--- a/main.js
+++ b/main.js
@@ -427,6 +427,11 @@ function getPropertyValue(prop) {
 window.generateItemDescription = function generateItemDescription(itemName, item, dropdownId) {
   if (!item) return '';
 
+  // Crafted items have complete descriptions - always use them
+  if (item.isCrafted && item.description) {
+    return item.description;
+  }
+
   // Items with baseType are dynamic - always regenerate them
   const isDynamic = item.baseType;
 


### PR DESCRIPTION
Crafted items weren't showing descriptions because generateItemDescription() was treating them as dynamic items (they have baseType property) and ignoring their pre-built descriptions.

Added check: if item.isCrafted && item.description, return it immediately.

Now crafted items display their full descriptions with base stats, fixed properties, and affixes when selected from dropdown.