### PR TITLE
Fix craft button by exposing affixDatabase globally

### DIFF
--- a/craftedItems.js
+++ b/craftedItems.js
@@ -473,3 +473,7 @@ class CraftedItemsSystem {
 
 // Initialize global crafted items system
 window.craftedItemsSystem = new CraftedItemsSystem();
+
+// Expose affix database and item type categories globally for UI access
+window.affixDatabase = affixDatabase;
+window.itemTypeCategories = itemTypeCategories;

--- a/main.js
+++ b/main.js
@@ -1134,7 +1134,7 @@ function openCraftingModal() {
     prefixHeader.style.cssText = 'color: #ffd700; margin: 10px 0; font-size: 14px;';
     affixesContainer.appendChild(prefixHeader);
 
-    for (const [affixKey, affixData] of Object.entries(window.craftedItemsSystem.affixesPool.prefixes)) {
+    for (const [affixKey, affixData] of Object.entries(window.affixDatabase.prefixes)) {
       affixesContainer.appendChild(createAffixSlider(affixKey, affixData, 'prefix'));
     }
 
@@ -1144,7 +1144,7 @@ function openCraftingModal() {
     suffixHeader.style.cssText = 'color: #ffd700; margin: 15px 0 10px 0; font-size: 14px;';
     affixesContainer.appendChild(suffixHeader);
 
-    for (const [affixKey, affixData] of Object.entries(window.craftedItemsSystem.affixesPool.suffixes)) {
+    for (const [affixKey, affixData] of Object.entries(window.affixDatabase.suffixes)) {
       affixesContainer.appendChild(createAffixSlider(affixKey, affixData, 'suffix'));
     }
   }


### PR DESCRIPTION
- Exposed affixDatabase and itemTypeCategories via window object in craftedItems.js
- Updated main.js to use window.affixDatabase instead of window.craftedItemsSystem.affixesPool
- Fixes TypeError: Cannot read properties of undefined (reading 'prefixes') at main.js:1137