### PR TITLE
Implement affix-based required level logic for crafted items

### DIFF
--- a/main.js
+++ b/main.js
@@ -1619,6 +1619,12 @@ function createCraftedItem() {
     suffixes: {}
   };
 
+  // Also collect affix names for required level calculation
+  const affixSelection = {
+    prefixes: {},
+    suffixes: {}
+  };
+
   // Collect prefixes
   const prefixCheckboxes = document.querySelectorAll('input[id^="check_prefix_"]');
   prefixCheckboxes.forEach(checkbox => {
@@ -1631,6 +1637,8 @@ function createCraftedItem() {
         const value = parseInt(slider.value);
         // Add to existing value if property already exists (multiple affixes with same property)
         affixes.prefixes[propKey] = (affixes.prefixes[propKey] || 0) + value;
+        // Track selected prefix name for required level calculation
+        affixSelection.prefixes[affixKey] = true;
       }
     }
   });
@@ -1647,6 +1655,8 @@ function createCraftedItem() {
         const value = parseInt(slider.value);
         // Add to existing value if property already exists
         affixes.suffixes[propKey] = (affixes.suffixes[propKey] || 0) + value;
+        // Track selected suffix name for required level calculation
+        affixSelection.suffixes[affixKey] = true;
       }
     }
   });
@@ -1660,8 +1670,8 @@ function createCraftedItem() {
     fixedProperties[propKey] = value;
   });
 
-  // Create the crafted item with fixed properties
-  const craftedItem = window.craftedItemsSystem.createCraftedItem(name, baseType, craftType, affixes, fixedProperties);
+  // Create the crafted item with fixed properties and affix selection for required level calculation
+  const craftedItem = window.craftedItemsSystem.createCraftedItem(name, baseType, craftType, affixes, fixedProperties, affixSelection);
 
   if (!craftedItem) {
     alert('Failed to create crafted item. Check your inputs and try again.');


### PR DESCRIPTION
- Calculate required level as max(highest_affix_reqLvl, baseRequiredLevel)
- Modified main.js to collect and pass selected affix names to createCraftedItem
- Modified craftedItems.js createCraftedItem to:
  - Accept affixSelection parameter containing selected prefix/suffix names
  - Calculate maximum required level from all selected affixes
  - Use max(baseRequiredLevel, maxAffixReqLevel) as final required level
- Example: Crown (baseReqLvl=13) + Quality suffix (reqLvl=22) = required level 22