### PR TITLE
Update character stats when crafted items are created, deleted, or re…

### DIFF
--- a/main.js
+++ b/main.js
@@ -1526,6 +1526,15 @@ async function reloadCraftedItemsFromBackend() {
     window.craftedItemsSystem.loadFromData(craftedItems);
     populateCraftedItemsList();
     refreshItemDropdowns();
+
+    // Update stats display
+    if (typeof window.unifiedSocketSystem?.calculateAllStats === 'function') {
+      window.unifiedSocketSystem.calculateAllStats();
+    }
+    if (typeof window.unifiedSocketSystem?.updateStatsDisplay === 'function') {
+      window.unifiedSocketSystem.updateStatsDisplay();
+    }
+
     alert(`Reloaded ${craftedItems.length} items from server`);
   } catch (error) {
     console.error('Failed to reload crafted items:', error);
@@ -1556,6 +1565,14 @@ async function deleteCraftedItemConfirm(craftId) {
     // Refresh UI
     populateCraftedItemsList();
     refreshItemDropdowns();
+
+    // Update stats display to reflect deletion of crafted item
+    if (typeof window.unifiedSocketSystem?.calculateAllStats === 'function') {
+      window.unifiedSocketSystem.calculateAllStats();
+    }
+    if (typeof window.unifiedSocketSystem?.updateStatsDisplay === 'function') {
+      window.unifiedSocketSystem.updateStatsDisplay();
+    }
 
     alert(`Deleted "${item.fullName}"`);
   } catch (error) {
@@ -1689,6 +1706,14 @@ function createCraftedItem() {
         // Refresh items list in modal
         populateCraftedItemsList();
 
+        // Update stats display to reflect crafted item properties
+        if (typeof window.unifiedSocketSystem?.calculateAllStats === 'function') {
+          window.unifiedSocketSystem.calculateAllStats();
+        }
+        if (typeof window.unifiedSocketSystem?.updateStatsDisplay === 'function') {
+          window.unifiedSocketSystem.updateStatsDisplay();
+        }
+
         // Show success message
         if (window.notificationSystem) {
           window.notificationSystem.success('Crafted Item Created!', `${craftedItem.fullName} has been created and saved.`, { duration: 4000 });
@@ -1705,6 +1730,14 @@ function createCraftedItem() {
     // No login - just update local
     refreshItemDropdowns();
     populateCraftedItemsList();
+
+    // Update stats display to reflect crafted item properties
+    if (typeof window.unifiedSocketSystem?.calculateAllStats === 'function') {
+      window.unifiedSocketSystem.calculateAllStats();
+    }
+    if (typeof window.unifiedSocketSystem?.updateStatsDisplay === 'function') {
+      window.unifiedSocketSystem.updateStatsDisplay();
+    }
 
     if (window.notificationSystem) {
       window.notificationSystem.success('Crafted Item Created!', `${craftedItem.fullName} has been created.`, { duration: 4000 });


### PR DESCRIPTION
…loaded

- Added calculateAllStats() and updateStatsDisplay() calls to createCraftedItem() so Str/Dex/Vit/Enr totals update when crafted items are created

- Added stats update to deleteCraftedItemConfirm() so totals update when deleted

- Added stats update to reloadCraftedItemsFromBackend() so totals update when reloaded

This ensures the left-side stat indicators (green values) always reflect current character stats including all equipped and crafted items.