### PR TITLE
Fix crafted items not contributing to character stats

### DIFF
--- a/character.js
+++ b/character.js
@@ -384,13 +384,8 @@ getDirectLifeManaFromItems() {
       return;
     }
 
-    const itemData = window.itemList || itemList;
-    if (!itemData) {
-      //(`  ❌ ${section}: No itemList found`);
-      return;
-    }
-
-    const item = itemData[dropdownElement.value];
+    // Use global item lookup to support both regular and crafted items
+    const item = window.getItemData(dropdownElement.value);
     if (!item) {
       //(`  ❌ ${section}: Item not found in itemList`);
       return;
@@ -523,10 +518,8 @@ getDirectLifeManaFromItems() {
       const dropdownElement = document.getElementById(dropdown);
       if (!dropdownElement || !dropdownElement.value) return;
 
-      const itemData = window.itemList || itemList;
-      if (!itemData) return;
-
-      const item = itemData[dropdownElement.value];
+      // Use global item lookup to support both regular and crafted items
+      const item = window.getItemData(dropdownElement.value);
       if (!item) return;
 
       const actualRequiredLevel = this.getActualRequiredLevel(section, dropdownElement.value);


### PR DESCRIPTION
Problem: When equipping crafted items, their stats (str/dex/vit/enr, to life, to mana) were not being calculated and green stat indicators were not appearing.

Root cause: The stat calculation functions in character.js were directly looking up items in window.itemList, but crafted items are stored separately in window.craftedItemsSystem.craftedItems.

Solution: Replace direct itemList lookups with window.getItemData() which correctly handles both regular and crafted items:
- For regular items: returns itemList[itemName] (same as before)
- For crafted items: returns the crafted item object from craftedItemsSystem

Changes:
- getAllItemBonuses(): Use window.getItemData() instead of itemData[dropdownElement.value]
- getDirectLifeManaFromItems(): Use window.getItemData() instead of itemData[dropdownElement.value]

This fix ensures crafted items now:
✅ Contribute str/dex/vit/enr to character stats
✅ Show green indicators when equipped
✅ Contribute "to life" and "to mana" to character counter ✅ Trigger stat recalculation properly when equipped

No changes to regular items - they continue to work exactly as before.