### PR TITLE
Add required level display to affixes in crafting modal

### DIFF
--- a/main.js
+++ b/main.js
@@ -1337,9 +1337,10 @@ function refreshAffixesForBaseType(baseType) {
     `;
 
     const label = document.createElement('label');
-    label.style.cssText = 'display: block; font-size: 12px; margin-bottom: 8px; color: #FF9900; text-shadow: 0 0 3px rgba(255, 215, 0, 0.3);';
+    label.style.cssText = 'display: flex; justify-content: space-between; align-items: center; font-size: 12px; margin-bottom: 8px; color: #FF9900; text-shadow: 0 0 3px rgba(255, 215, 0, 0.3);';
     const displayLabel = `${affixKey} (${propLabels[propKey] || propKey})`;
-    label.innerHTML = `${displayLabel} <span id="val_${affixType}_${affixKey}" style="color: #0f9eff; margin-left: 5px;">[0]</span>`;
+    const reqLvlText = affixData.reqLvl ? `<span style="color: #888; font-size: 11px; margin-left: 10px;">Req Lvl: ${affixData.reqLvl}</span>` : '';
+    label.innerHTML = `<span>${displayLabel} <span id="val_${affixType}_${affixKey}" style="color: #0f9eff; margin-left: 5px;">[0]</span></span>${reqLvlText}`;
 
     const checkbox = document.createElement('input');
     checkbox.type = 'checkbox';


### PR DESCRIPTION
Problem: When selecting affixes in the crafting modal, users couldn't see what required level each affix adds to the item, making it hard to plan their crafts.

Solution:
- Modified createAffixSlider() to display required level next to each affix
- Changed label layout from block to flex with justify-content: space-between
- Added "Req Lvl: X" label on the right side in gray text (color: #888)
- Only shows if affix has a reqLvl property defined

Example display:
  Jagged (+% Enhanced Damage) [0]          Req Lvl: 12

Benefits:
✅ Users can see required level for each affix while selecting ✅ Helps plan crafts to hit desired level requirements ✅ Clear visual separation with gray text on the right ✅ No breaking changes - only adds info if available