### PR TITLE
Fix crafted items not appearing in shared builds removed if (window.auth?.isLoggedIn() && window.craftedItemsSystem)

### DIFF
--- a/main.js
+++ b/main.js
@@ -373,8 +373,8 @@ function populateItemDropdowns() {
       dropdown.appendChild(option);
     });
 
-    // Add crafted items if user is logged in (continue naturally after regular items)
-    if (window.auth?.isLoggedIn() && window.craftedItemsSystem) {
+    // Add crafted items (from user's account or loaded from shared build)
+    if (window.craftedItemsSystem) {
       const craftedItems = window.craftedItemsSystem.getCraftedItemsByType(itemType);
       craftedItems.forEach(craftedItem => {
         const option = document.createElement('option');


### PR DESCRIPTION
- Remove login requirement from dropdown population
- Crafted items now show in dropdowns for anyone viewing shared builds
- Data is already loaded from build snapshot, just needed UI to display it
- Enables proper sharing of builds that include crafted items