### PR TITLE
Fix crafted items dropdown refresh timing in shared builds

### DIFF
--- a/character-data.js
+++ b/character-data.js
@@ -242,6 +242,10 @@ window.loadCharacterFromData = function(data) {
         // Load crafted items
         if (data.crafted_items && window.craftedItemsSystem) {
             window.craftedItemsSystem.loadFromData(data.crafted_items);
+            // Refresh dropdowns to include the loaded crafted items
+            if (typeof populateItemDropdowns === 'function') {
+                populateItemDropdowns();
+            }
         }
 
         // Set equipment


### PR DESCRIPTION
- Refresh dropdowns immediately after loading crafted items from build data
- Ensures dropdown options exist before equipment values are set
- Fixes issue where visitors couldn't see crafted items in shared builds
- Correct flow: load crafted items → refresh dropdowns → set equipment