### PR TITLE
Fix crafted items loading for logged-in users

### DIFF
--- a/character-data.js
+++ b/character-data.js
@@ -239,8 +239,9 @@ window.loadCharacterFromData = function(data) {
             
         }
 
-        // Load crafted items
-        if (data.crafted_items && window.craftedItemsSystem) {
+        // Load crafted items (only for visitors viewing shared builds)
+        // Logged-in users already have their crafted items loaded from the database
+        if (data.crafted_items && window.craftedItemsSystem && !window.auth?.isLoggedIn()) {
             // Filter to only include crafted items that are actually equipped in this build
             // This prevents showing all user's crafted items in shared builds
             const equippedItemNames = new Set(Object.values(data.equipment || {}));


### PR DESCRIPTION
- Only load crafted items from build data for non-logged-in visitors
- Logged-in users already have their full crafted items collection loaded from database
- Prevents overwriting user's crafted items when loading their own builds
- Visitors still see only equipped crafted items in shared builds (correct behavior)

Bug fix: Loading your own build was replacing all your crafted items with only equipped ones