### PR TITLE
Fix ethereal functionality for dynamic items (weapons and armor)

### DIFF
--- a/main.js
+++ b/main.js
@@ -652,6 +652,11 @@ window.generateItemDescription = function generateItemDescription(itemName, item
     });
   }
 
+  // Add ethereal text if the item is ethereal
+  if (props.ethereal) {
+    html += ' <span style="color: #C0C0C0">Ethereal</span>';
+  }
+
   return html;
 }
 


### PR DESCRIPTION
Issues fixed:
- Input boxes were getting locked after applying ethereal to dynamic items
- Weapon damage wasn't increasing when ethereal was applied to dynamic weapons
- Armor defense wasn't being calculated correctly for dynamic armor items

Changes:
1. Updated calculateItemDamage() to check properties.ethereal in addition to description
2. Updated calculateItemDefense() to check properties.ethereal in addition to description
3. Updated makeEtherealItem() to handle dynamic items differently:
   - For dynamic items: only set properties.ethereal flag
   - For static items: modify description directly (old behavior)
4. Updated generateItemDescription() to add ethereal text when properties.ethereal is true
5. Updated ethereal check in makeEtherealItem() to check both properties and description

This ensures dynamic items (like True Silver Maiden Javelin and Biggin's Bonnet):
- Keep their input boxes functional after applying ethereal
- Get correct damage/defense bonuses from ethereal (1.5x multiplier)
- Continue to work with socket system properly