### PR TITLE
Fix dynamic item ethereal - remove updateWeaponDamageDisplay call

### DIFF
--- a/itemUpgrade.js
+++ b/itemUpgrade.js
@@ -4438,12 +4438,9 @@ function makeEtherealItem(category) {
         currentItemData.properties.ethereal = true;
       }
 
-      // For non-crafted dynamic weapons (like True Silver), we need to recalculate damage
-      // because calculateItemDamage is used, not the crafted item formula
-      if (typeof window.updateWeaponDamageDisplay === 'function') {
-        console.log('Calling updateWeaponDamageDisplay for', currentItem);
-        window.updateWeaponDamageDisplay();
-      }
+      // DON'T call updateWeaponDamageDisplay - it causes errors for dynamic items
+      // Just let the socket system regenerate everything at the end via updateAll()
+      console.log('Ethereal flag toggled, will regenerate via socket system');
     } else {
       // For static items
       let description = currentItemData.description;


### PR DESCRIPTION
ISSUE:
updateWeaponDamageDisplay() was causing errors for dynamic items because:
- It tries to access properties.onehandmin/twohandmin that may not exist yet
- Dynamic items (javelins, crafted items) don't have damage properties set until generateItemDescription() is called
- Line 5254 error: Cannot read properties of undefined (reading 'properties')

FIX:
For dynamic items, just toggle the ethereal flag and let the socket system handle everything via updateAll() at the end. The socket system will:
1. Call generateItemDescription() which reads the ethereal flag
2. Apply 1.5x multiplier to damage/defense calculations
3. Generate proper description with input boxes intact
4. Display updated values

This is the correct approach for dynamic items - they regenerate their description every time, so we just need to set the flag and trigger regeneration.