### PR TITLE
Fix ethereal defense for dynamic items and enable toggle for static i…

### DIFF
--- a/main.js
+++ b/main.js
@@ -579,7 +579,18 @@ window.generateItemDescription = function generateItemDescription(itemName, item
 
   // Map property keys to display format
   const propertyDisplay = {
-    defense: (val) => defenseDisplay !== null ? defenseDisplay : `Defense: ${val}`,
+    defense: (val) => {
+      // If defenseDisplay is set (from edef calculation), use it
+      if (defenseDisplay !== null) return defenseDisplay;
+
+      // For static defense values, apply ethereal multiplier if item is ethereal
+      if (props.ethereal && val) {
+        const ethDefense = Math.floor(val * 1.5);
+        return `Defense: ${ethDefense}`;
+      }
+
+      return `Defense: ${val}`;
+    },
     smitedmgmin: (val, prop) => `Smite Damage: ${val} to ${props.smitedmgmax || '?'}`,
     smitedmgmax: () => '', // Skip, handled by smitedmgmin
     onehandmin: (val, prop) => `One-Hand Damage: ${val} to ${props.onehandmax || '?'}, Avg ${Math.round((val + (props.onehandmax || 0)) / 2 * 10) / 10}`,


### PR DESCRIPTION
…tems

FIX 1 - Dynamic items ethereal defense not increasing: ISSUE: Items like Biggin's Bonnet have static defense values (defense: 19) without edef property. The ethereal multiplier was only applied when edef existed, so static defense values weren't being multiplied.

FIX: Updated propertyDisplay.defense to apply ethereal multiplier (1.5x) to static defense values when properties.ethereal is true.

FIX 2 - Cannot remove ethereal from static items:
ISSUE: makeItemEthereal() had early return when ethereal was already applied, with comment 'Can't remove ethereal for static items (not implemented)'

FIX: Implemented full toggle support for static items:
- If ethereal: Remove ethereal flag, remove text, recalculate without 1.5x
- If not ethereal: Add ethereal flag, add text, recalculate with 1.5x

Now works for both adding AND removing ethereal for:
- Static weapons: Recalculates damage
- Static armor/shields: Recalculates defense
- Dynamic items: Already supported via previous commits