### PR TITLE
Add in-memory item state system - remember corruptions/sockets/ethere…

### DIFF
--- a/index.html
+++ b/index.html
@@ -784,6 +784,7 @@
 <script src="skills.js"></script>
 <script src="notification.js"></script>
 <script src="character-data.js"></script>
+<script src="itemState.js"></script>
 <script src="auth.js"></script>
 <script src="auth-ui.js"></script>
 <script src="main.js"></script>


### PR DESCRIPTION
…al/stats when switching items

ISSUE: When switching items in dropdown, all modifications (corruptions, sockets, ethereal status, variable stats) were lost. Users had to reconfigure items every time they wanted to compare different items.

SOLUTION: Simple in-memory item state system (no localStorage)

NEW FILE: itemState.js
- window.itemStates{} - stores item modifications in memory (session only)
- saveItemState() - saves corruption, sockets, ethereal, properties before switching
- restoreItemState() - restores saved state after switching to item
- clearItemStateIfRequirementsNotMet() - clears state if level/str/dex too low

MODIFIED: socket.js (dropdown change handler)
- Save old item state BEFORE switching (line 1365-1367)
- Check requirements and clear state if not met (line 1373-1389)
- Restore new item state AFTER switching (line 1429-1431)
- Track previous dropdown value using dataset.previousValue

MODIFIED: index.html
- Added itemState.js script after character-data.js

HOW IT WORKS:
1. User selects "Shako", adds corruption, adds sockets, makes ethereal
2. User switches to "Arreat's Face" - Shako state is SAVED
3. User configures Arreat's Face
4. User switches back to "Shako" - all previous work is RESTORED
   - Corruption restored
   - Sockets restored (with items in them)
   - Ethereal status restored
   - Variable stats restored

WHEN STATE IS CLEARED:
- Character level < required level
- Character strength < required strength
- Character dexterity < required dexterity
- Page reload (session ends)

BENEFITS:
- No localStorage complexity
- Easy item comparison without losing work
- Minimal code changes
- Works with dynamic and static items