### PR TITLE
Fix ethereal text not appearing and socket images not loading after r…

### DIFF
--- a/itemState.js
+++ b/itemState.js
@@ -69,6 +69,11 @@ window.restoreItemState = function(dropdownId, itemName, section) {
     }
   }
 
+  // Trigger immediate description update to sync ethereal text with properties
+  if (window.unifiedSocketSystem && window.unifiedSocketSystem.updateAll) {
+    window.unifiedSocketSystem.updateAll();
+  }
+
   // Update ethereal button state based on restored ethereal flag
   const category = section; // helm, armor, weapon, shield, etc.
   const etherealBtn = document.querySelector(`button[onclick*="makeEtherealItem('${category}')"]`);
@@ -90,7 +95,7 @@ window.restoreItemState = function(dropdownId, itemName, section) {
       window.unifiedSocketSystem.setSocketCount(section, savedState.socketCount);
     }
 
-    // Restore socket items after a small delay to ensure sockets exist
+    // Restore socket items at the very end after all other updates complete
     setTimeout(() => {
       savedState.sockets.forEach(socketInfo => {
         const socketSlot = document.querySelector(
@@ -103,14 +108,11 @@ window.restoreItemState = function(dropdownId, itemName, section) {
           socketSlot.dataset.stats = socketInfo.stats;
           socketSlot.dataset.levelReq = socketInfo.levelReq;
 
-          // Add image
+          // Add image - load at the very end
           socketSlot.innerHTML = `<img src="images/${socketInfo.itemName}.jpg" alt="${socketInfo.itemName}">`;
         }
       });
-
-      // Don't call updateAll() here - let socket.js handle it after restoration completes
-      // This avoids timing conflicts where updateAll() might run before sockets are restored
-    }, 10);
+    }, 100);
   }
 };
 


### PR DESCRIPTION
…estore

ISSUE 1: Ethereal flag was restored but "Ethereal" text didn't appear in description
- Button showed "Remove Ethereal" correctly
- But description was missing ethereal text
- Clicking button again would toggle incorrectly, breaking defense bonus

ROOT CAUSE:
- properties.ethereal was restored to true
- But description wasn't regenerated immediately
- makeEtherealItem() detected ethereal from properties but description was out of sync
- This caused state confusion when clicking the button

SOLUTION:
- Added immediate updateAll() call after restoring properties/corruption
- This regenerates description with ethereal text before button update
- Now properties.ethereal and description text are in sync

ISSUE 2: Socket images failing to load with ERR_FILE_NOT_FOUND

ROOT CAUSE:
- Socket images were being restored too early (10ms delay)
- Conflicted with other updates happening simultaneously

SOLUTION:
- Increased socket restoration delay from 10ms to 100ms
- Sockets now load at the very end after all other updates complete
- This ensures socket slots exist and are ready before images are added

TIMELINE NOW:
1. Restore properties/corruption → immediate updateAll() (ethereal text appears)
2. Update ethereal button state
3. socket.js updateAll() at 50ms (merges socket stats if any)
4. Restore socket images at 100ms (after everything else is done)