### PR TITLE
Fix socket descriptions not being merged into item description after …

### DIFF
--- a/itemState.js
+++ b/itemState.js
@@ -69,10 +69,7 @@ window.restoreItemState = function(dropdownId, itemName, section) {
     }
   }
 
-  // Trigger immediate description update to sync ethereal text with properties
-  if (window.unifiedSocketSystem && window.unifiedSocketSystem.updateAll) {
-    window.unifiedSocketSystem.updateAll();
-  }
+  // Don't call updateAll() here - we'll call it after sockets are restored (or let socket.js handle it)
 
   // Update ethereal button state based on restored ethereal flag
   const category = section; // helm, armor, weapon, shield, etc.
@@ -89,7 +86,9 @@ window.restoreItemState = function(dropdownId, itemName, section) {
   }
 
   // Restore sockets
-  if (savedState.sockets && window.unifiedSocketSystem) {
+  const hasSockets = savedState.sockets && savedState.sockets.length > 0;
+
+  if (hasSockets && window.unifiedSocketSystem) {
     // Set socket count first
     if (savedState.socketCount) {
       window.unifiedSocketSystem.setSocketCount(section, savedState.socketCount);
@@ -112,7 +111,17 @@ window.restoreItemState = function(dropdownId, itemName, section) {
           socketSlot.innerHTML = `<img src="images/${socketInfo.itemName}.jpg" alt="${socketInfo.itemName}">`;
         }
       });
+
+      // CRITICAL: Call updateAll() AFTER sockets are restored to merge their stats into description
+      if (window.unifiedSocketSystem.updateAll) {
+        window.unifiedSocketSystem.updateAll();
+      }
     }, 100);
+  } else {
+    // No sockets to restore - call updateAll() immediately to update ethereal/corruption
+    if (window.unifiedSocketSystem && window.unifiedSocketSystem.updateAll) {
+      window.unifiedSocketSystem.updateAll();
+    }
   }
 };
 


### PR DESCRIPTION
…restore

ISSUE: When restoring items with sockets:
1. First switch with sockets only showed one socketed item's properties (even with 2 sockets)
2. Switching back to saved item showed no socket properties in description at all
3. Socket stats were correctly parsed to character stats, but not merged into description

ROOT CAUSE: Timing issue with multiple updateAll() calls
- restoreItemState() called updateAll() immediately (no sockets restored yet)
- socket.js called updateAll() at 50ms (still no sockets restored)
- Sockets were restored at 100ms but no updateAll() was called after
- Socket stats never got merged into the description

SOLUTION: Smart updateAll() timing based on socket presence

IF item has sockets to restore:
  1. Restore socket slots and images at 100ms
  2. Call updateAll() AFTER sockets are restored (at 100ms)
  3. Socket stats now get properly merged into description

IF item has NO sockets:
  1. Call updateAll() immediately to show ethereal/corruption
  2. No need to wait for sockets

TIMELINE NOW (with sockets):
- Immediate: Restore properties, corruption, update button states
- 50ms: socket.js updateAll() (runs but sockets not ready yet)
- 100ms: Restore socket images → THEN call updateAll() to merge socket stats
- Result: Socket descriptions properly merged

TIMELINE (without sockets):
- Immediate: Restore properties, corruption, update button states, call updateAll()
- Result: Ethereal/corruption text appears immediately

BENEFITS:
- Socket descriptions now properly merged for all sockets (not just one)
- Single source of truth: updateAll() called once AFTER sockets are in place
- No more lost socket descriptions when switching items