### PR TITLE
Fix socket images not loading by separating from updateAll() timing

### DIFF
--- a/itemState.js
+++ b/itemState.js
@@ -94,7 +94,7 @@ window.restoreItemState = function(dropdownId, itemName, section) {
       window.unifiedSocketSystem.setSocketCount(section, savedState.socketCount);
     }
 
-    // Restore socket items at the very end after all other updates complete
+    // First: Restore socket data (without images) at 80ms
     setTimeout(() => {
       savedState.sockets.forEach(socketInfo => {
         const socketSlot = document.querySelector(
@@ -106,17 +106,28 @@ window.restoreItemState = function(dropdownId, itemName, section) {
           socketSlot.dataset.itemName = socketInfo.itemName;
           socketSlot.dataset.stats = socketInfo.stats;
           socketSlot.dataset.levelReq = socketInfo.levelReq;
-
-          // Add image - load at the very end
-          socketSlot.innerHTML = `<img src="images/${socketInfo.itemName}.jpg" alt="${socketInfo.itemName}">`;
         }
       });
 
-      // CRITICAL: Call updateAll() AFTER sockets are restored to merge their stats into description
+      // Call updateAll() to merge socket stats into description
       if (window.unifiedSocketSystem.updateAll) {
         window.unifiedSocketSystem.updateAll();
       }
-    }, 100);
+
+      // THEN: Add socket images after updateAll() completes (at 150ms total)
+      setTimeout(() => {
+        savedState.sockets.forEach(socketInfo => {
+          const socketSlot = document.querySelector(
+            `.socket-container[data-section="${section}"] .socket-slot:nth-child(${socketInfo.index + 1})`
+          );
+
+          if (socketSlot && !socketSlot.querySelector('img')) {
+            // Add image only if it doesn't already exist
+            socketSlot.innerHTML = `<img src="images/${socketInfo.itemName}.jpg" alt="${socketInfo.itemName}">`;
+          }
+        });
+      }, 70);
+    }, 80);
   } else {
     // No sockets to restore - call updateAll() immediately to update ethereal/corruption
     if (window.unifiedSocketSystem && window.unifiedSocketSystem.updateAll) {


### PR DESCRIPTION
ISSUE: Socket images never loaded after restoration, even though socket stats were correctly merged into description and parsed to character stats.

ROOT CAUSE: Timing conflict between image insertion and updateAll()
- Images were added to socket slots
- updateAll() was called immediately after
- updateAll() regenerated the socket slots, clearing the images we just added

SOLUTION: Separate socket data restoration from image loading

TWO-PHASE RESTORATION:

Phase 1 (80ms):
- Restore socket data (filled class, dataset.itemName, dataset.stats, dataset.levelReq)
- Call updateAll() to merge socket stats into description
- NO images added yet

Phase 2 (150ms total = 80ms + 70ms):
- Add socket images AFTER updateAll() has completed
- Check if image already exists before adding
- Images now stay in place since updateAll() already ran

TIMELINE:
1. Immediate: Restore properties, corruption, button states
2. 50ms: socket.js updateAll() (might run but sockets not ready)
3. 80ms: Restore socket data → call updateAll() to merge stats
4. 150ms: Add socket images (AFTER updateAll() completes)

BENEFITS:
- Socket stats merged into description correctly
- Socket images now load and stay visible
- No conflict between updateAll() and image insertion
- Clean separation of data restoration vs visual updates