### PR TITLE
Fix ethereal toggle on corrupted items - prevent state restoration ov…

### DIFF
--- a/itemUpgrade.js
+++ b/itemUpgrade.js
@@ -4431,17 +4431,16 @@ function makeEtherealItem(category) {
       // For dynamic items: toggle ethereal property
       if (isCurrentlyEthereal) {
         // Remove ethereal
-        console.log('Removing ethereal from', currentItem);
         currentItemData.properties.ethereal = false;
       } else {
         // Add ethereal
-        console.log('Adding ethereal to', currentItem);
         currentItemData.properties.ethereal = true;
       }
 
-      // DON'T call updateWeaponDamageDisplay - it causes errors for dynamic items
-      // Just let the socket system regenerate everything at the end via updateAll()
-      console.log('Ethereal flag toggled, will regenerate via socket system');
+      // Trigger update to regenerate description with/without ethereal
+      if (window.unifiedSocketSystem && window.unifiedSocketSystem.updateAll) {
+        window.unifiedSocketSystem.updateAll();
+      }
     } else {
       // For static items
       let description = currentItemData.description;
@@ -4554,16 +4553,16 @@ function makeEtherealItem(category) {
       // For dynamic items: toggle ethereal property
       if (isCurrentlyEthereal) {
         // Remove ethereal
-        console.log('Removing ethereal from', currentItem, '(armor/helm)');
         currentItemData.properties.ethereal = false;
       } else {
         // Add ethereal
-        console.log('Adding ethereal to', currentItem, '(armor/helm)');
         currentItemData.properties.ethereal = true;
       }
 
-      // Let the socket system handle regeneration
-      console.log('Ethereal flag set, letting socket system regenerate');
+      // Trigger update to regenerate description with/without ethereal
+      if (window.unifiedSocketSystem && window.unifiedSocketSystem.updateAll) {
+        window.unifiedSocketSystem.updateAll();
+      }
     } else {
       // For static items
       let lines = currentItemData.description.split("<br>");

--- a/socket.js
+++ b/socket.js
@@ -1361,6 +1361,15 @@
             const oldItemName = dropdown.dataset.previousValue;
             const newItemName = dropdown.value;
 
+            // Only save/restore if actually switching to a different item
+            if (oldItemName === newItemName) {
+              // Same item - just update display, don't save/restore
+              this.calculateAllStats();
+              this.updateStatsDisplay();
+              setTimeout(() => this.updateAll(), 50);
+              return;
+            }
+
             // SAVE current item state BEFORE switching
             if (oldItemName && typeof window.saveItemState === 'function') {
               window.saveItemState(dropdownId, oldItemName, section);


### PR DESCRIPTION
…erride

ISSUE: Cannot remove ethereal from corrupted items properly
- Click remove ethereal: defense goes down (correct) but text stays
- Cannot toggle ethereal correctly after corruption

ROOT CAUSE: makeEtherealItem() dispatches change event, triggering save/restore
1. User clicks "Remove Ethereal" button2. makeEtherealItem() sets properties.ethereal = false
3. Dispatches change event on dropdown (line 4613)
4. Socket.js change handler runs
5. Sees saved state exists and RESTORES it (with old ethereal=true)
6. This overwrites the ethereal change we just made!

SOLUTION:

socket.js:
- Check if oldItemName === newItemName
- If same item (not actually switching), skip save/restore logic
- Just update display and return early
- This prevents saved state from overriding ethereal toggle

itemUpgrade.js:
- Call updateAll() immediately after toggling ethereal for dynamic items
- This ensures description is regenerated with correct ethereal state
- Removed console.log statements

NOW: Ethereal toggle works correctly on corrupted items
- Ethereal text removed when untoggled
- Defense calculated correctly
- Can toggle ethereal on/off repeatedly