### PR TITLE
Update saved state when ethereal is toggled to keep them in sync

### DIFF
--- a/itemUpgrade.js
+++ b/itemUpgrade.js
@@ -4597,6 +4597,16 @@ function makeEtherealItem(category) {
     }
   }
 
+  // Update saved state if it exists (so ethereal toggle is remembered)
+  const dropdownId = `${category}-dropdown`;
+  const stateKey = `${dropdownId}_${currentItem}`;
+  if (window.itemStates && window.itemStates[stateKey]) {
+    window.itemStates[stateKey].ethereal = currentItemData.properties.ethereal || false;
+    if (window.itemStates[stateKey].properties) {
+      window.itemStates[stateKey].properties.ethereal = currentItemData.properties.ethereal || false;
+    }
+  }
+
   // Reapply socket corruption if there was one
   if (socketCorruption) {
     const socketMatch = socketCorruption.match(/Socketed \((\d+)\)/);


### PR DESCRIPTION
ISSUE: Ethereal toggle sometimes works, sometimes doesn't - very inconsistent Especially problematic with corrupted items

ROOT CAUSE: Saved state not updated when ethereal toggled
1. Item has ethereal=true, corruption applied, state saved
2. User toggles ethereal off → item.properties.ethereal = false (correct)
3. Saved state STILL has ethereal=true (never updated!)
4. Any restore or refresh brings back ethereal=true from saved state
5. Creates inconsistent behavior - works sometimes, fails other times

SOLUTION: Update saved state immediately after toggling ethereal

Added after ethereal toggle (line 4600-4608):
- Check if saved state exists for this item
- Update both savedState.ethereal and savedState.properties.ethereal
- Now saved state stays in sync with actual item state

FLOW NOW:
1. Toggle ethereal off → properties.ethereal = false
2. Update saved state → savedState.ethereal = false
3. Switch to another item and back → restores ethereal=false (correct!)
4. Ethereal toggle is now remembered consistently

This fixes the inconsistent behavior with corrupted items.