### PR TITLE
Update saved state when corrupting items to preserve ethereal status

### DIFF
--- a/corrupt.js
+++ b/corrupt.js
@@ -954,6 +954,20 @@ function applySocketCorruptionFromModal(corruption) {
     window.unifiedSocketSystem.setSocketCount(section, socketCount);
   }
 
+  // Update saved state if it exists (so socket corruption is remembered with current ethereal status)
+  if (window.itemStates) {
+    const stateKey = `${currentCorruptionSlot}_${itemName}`;
+    if (window.itemStates[stateKey]) {
+      // Update corruption in saved state
+      window.itemStates[stateKey].corruption = window.itemCorruptions[currentCorruptionSlot];
+      // Also update properties to include current ethereal status
+      if (item.properties) {
+        window.itemStates[stateKey].properties = JSON.parse(JSON.stringify(item.properties));
+        window.itemStates[stateKey].ethereal = item.properties.ethereal || false;
+      }
+    }
+  }
+
   // Trigger item display update
   triggerItemUpdate(currentCorruptionSlot);
 
@@ -1145,6 +1159,21 @@ function applyCorruptionToItem(corruptionText) {
         });
 
         item.description = updatedLines.join('<br>');
+      }
+    }
+  }
+
+  // Update saved state if it exists (so corruption is remembered with current ethereal status)
+  const section = SECTION_MAP[currentCorruptionSlot];
+  if (section && window.itemStates) {
+    const stateKey = `${currentCorruptionSlot}_${itemName}`;
+    if (window.itemStates[stateKey]) {
+      // Update corruption in saved state
+      window.itemStates[stateKey].corruption = window.itemCorruptions[currentCorruptionSlot];
+      // Also update properties to include current ethereal status
+      if (item.properties) {
+        window.itemStates[stateKey].properties = JSON.parse(JSON.stringify(item.properties));
+        window.itemStates[stateKey].ethereal = item.properties.ethereal || false;
       }
     }
   }


### PR DESCRIPTION
ISSUE: Ethereal first → corrupt workflow broken
1. Make item ethereal → saved state has ethereal=true
2. Add corruption → corruption applied BUT saved state NOT updated
3. Switch items and back → restored state has old corruption or ethereal data
4. Toggle ethereal → saved state updated, but out of sync with corruption
5. Cannot properly toggle ethereal on corrupted items made ethereal first

ROOT CAUSE: Corruption functions didn't update saved item state
- applyCorruptionToItem() stored corruption but didn't update saved state
- applySocketCorruptionFromModal() same issue
- This caused ethereal and corruption to get out of sync in saved state

SOLUTION: Update saved state when corruption is applied

corrupt.js changes:
1. After applyCorruptionToItem() (line 1152-1165):
   - Check if saved state exists for this item
   - Update savedState.corruption with new corruption
   - Update savedState.properties with current item properties
   - Update savedState.ethereal with current ethereal status

2. After applySocketCorruptionFromModal() (line 957-969):
   - Same updates for socket corruption

NOW BOTH WORKFLOWS WORK:
✅ Corrupt first → ethereal → toggle works
✅ Ethereal first → corrupt → toggle works
✅ Saved state always has current corruption + ethereal status in sync ✅ Can toggle ethereal on/off regardless of corruption order