### PR TITLE
Simplify state management - single refreshSavedState() for all modifi…

### DIFF
--- a/corrupt.js
+++ b/corrupt.js
@@ -954,18 +954,9 @@ function applySocketCorruptionFromModal(corruption) {
     window.unifiedSocketSystem.setSocketCount(section, socketCount);
   }
 
-  // Update saved state if it exists (so socket corruption is remembered with current ethereal status)
-  if (window.itemStates) {
-    const stateKey = `${currentCorruptionSlot}_${itemName}`;
-    if (window.itemStates[stateKey]) {
-      // Update corruption in saved state
-      window.itemStates[stateKey].corruption = window.itemCorruptions[currentCorruptionSlot];
-      // Also update properties to include current ethereal status
-      if (item.properties) {
-        window.itemStates[stateKey].properties = JSON.parse(JSON.stringify(item.properties));
-        window.itemStates[stateKey].ethereal = item.properties.ethereal || false;
-      }
-    }
+  // Refresh saved state to capture socket corruption + ethereal + sockets
+  if (section && typeof window.refreshSavedState === 'function') {
+    window.refreshSavedState(currentCorruptionSlot, section);
   }
 
   // Trigger item display update
@@ -1163,19 +1154,10 @@ function applyCorruptionToItem(corruptionText) {
     }
   }
 
-  // Update saved state if it exists (so corruption is remembered with current ethereal status)
+  // Refresh saved state to capture current corruption + ethereal + sockets
   const section = SECTION_MAP[currentCorruptionSlot];
-  if (section && window.itemStates) {
-    const stateKey = `${currentCorruptionSlot}_${itemName}`;
-    if (window.itemStates[stateKey]) {
-      // Update corruption in saved state
-      window.itemStates[stateKey].corruption = window.itemCorruptions[currentCorruptionSlot];
-      // Also update properties to include current ethereal status
-      if (item.properties) {
-        window.itemStates[stateKey].properties = JSON.parse(JSON.stringify(item.properties));
-        window.itemStates[stateKey].ethereal = item.properties.ethereal || false;
-      }
-    }
+  if (section && typeof window.refreshSavedState === 'function') {
+    window.refreshSavedState(currentCorruptionSlot, section);
   }
 
   // Trigger item display update

--- a/itemState.js
+++ b/itemState.js
@@ -5,13 +5,18 @@
 // Global storage for item states
 window.itemStates = {};
 
-// Save current item state before switching
-window.saveItemState = function(dropdownId, itemName, section) {
+// Refresh saved state for current item (call after any modification)
+window.refreshSavedState = function(dropdownId, section) {
+  const dropdown = document.getElementById(dropdownId);
+  if (!dropdown) return;
+
+  const itemName = dropdown.value;
   if (!itemName) return;
 
-  const stateKey = `${dropdownId}_${itemName}`;
   const item = window.getItemData(itemName);
   if (!item) return;
+
+  const stateKey = `${dropdownId}_${itemName}`;
 
   // Get socket data
   const socketData = [];
@@ -27,13 +32,19 @@ window.saveItemState = function(dropdownId, itemName, section) {
     });
   });
 
-  // Save complete state
+  // Save complete current state - ethereal is always last/most current
   window.itemStates[stateKey] = {
     corruption: window.itemCorruptions ? window.itemCorruptions[dropdownId] : null,
     sockets: socketData,
     ethereal: item.properties?.ethereal || false,
     properties: item.properties ? JSON.parse(JSON.stringify(item.properties)) : null
   };
+};
+
+// Save current item state before switching (just calls refresh)
+window.saveItemState = function(dropdownId, itemName, section) {
+  if (!itemName) return;
+  window.refreshSavedState(dropdownId, section);
 };
 
 // Restore item state after switching

--- a/itemUpgrade.js
+++ b/itemUpgrade.js
@@ -4597,14 +4597,10 @@ function makeEtherealItem(category) {
     }
   }
 
-  // Update saved state if it exists (so ethereal toggle is remembered)
+  // Refresh saved state to capture current ethereal status + sockets + corruption
   const dropdownId = `${category}-dropdown`;
-  const stateKey = `${dropdownId}_${currentItem}`;
-  if (window.itemStates && window.itemStates[stateKey]) {
-    window.itemStates[stateKey].ethereal = currentItemData.properties.ethereal || false;
-    if (window.itemStates[stateKey].properties) {
-      window.itemStates[stateKey].properties.ethereal = currentItemData.properties.ethereal || false;
-    }
+  if (typeof window.refreshSavedState === 'function') {
+    window.refreshSavedState(dropdownId, category);
   }
 
   // Reapply socket corruption if there was one

--- a/socket.js
+++ b/socket.js
@@ -1652,8 +1652,18 @@
       ['itemKey', 'category', 'itemName', 'stats', 'levelReq'].forEach(attr => {
         delete socket.dataset[attr];
       });
-      
+
       this.updateAll();
+
+      // Refresh saved state after socket cleared
+      const container = socket.closest('.socket-container');
+      const section = container?.dataset.section;
+      if (section && typeof window.refreshSavedState === 'function') {
+        const dropdownId = this.getSectionDropdownId(section);
+        if (dropdownId) {
+          window.refreshSavedState(dropdownId, section);
+        }
+      }
     }
 
     fillSocket(itemKey, category) {
@@ -1685,8 +1695,17 @@
     }
     
     this.hideSocketModal();
-    this.currentSocket = null;
     this.updateAll();
+
+    // Refresh saved state after socket filled
+    if (section && typeof window.refreshSavedState === 'function') {
+      const dropdownId = this.getSectionDropdownId(section);
+      if (dropdownId) {
+        window.refreshSavedState(dropdownId, section);
+      }
+    }
+
+    this.currentSocket = null;
   }
     // === MODAL CREATION ===
     createSocketModal() {


### PR DESCRIPTION
…cations

USER REQUEST: Make ethereal always saved last/correctly, simple solution

PROBLEM: We were trying to update saved state in multiple places with custom logic:
- itemUpgrade.js: custom ethereal update code
- corrupt.js: custom corruption + ethereal update code (2 places)
- socket.js: missing entirely when sockets added/removed This caused issues when operations happened in different orders (ethereal→corrupt→socket)

SOLUTION: Single source of truth - refreshSavedState()

NEW FUNCTION in itemState.js:
- window.refreshSavedState(dropdownId, section)
- Reads current state from DOM and item data
- Saves corruption, sockets, ethereal, properties
- Ethereal is always captured last/correctly
- Called after ANY modification

CALLED FROM:
1. itemUpgrade.js after ethereal toggle
2. corrupt.js after corruption applied (both types)
3. socket.js after socket filled
4. socket.js after socket cleared
5. socket.js when switching items (via saveItemState)

BENEFITS:
- Simple: One function, called everywhere
- Reliable: Always saves complete current state
- No custom update logic scattered everywhere
- Ethereal always saved correctly regardless of operation order
- Works for: ethereal→corrupt, corrupt→ethereal, socket→ethereal, any combination

Now saved state is ALWAYS current, no matter what you do to the item.