### PR TITLE
Fix ethereal toggle - call refreshSavedState() AFTER updateAll() comp…

### DIFF
--- a/corrupt.js
+++ b/corrupt.js
@@ -954,13 +954,13 @@ function applySocketCorruptionFromModal(corruption) {
     window.unifiedSocketSystem.setSocketCount(section, socketCount);
   }
 
-  // Refresh saved state to capture socket corruption + ethereal + sockets
-  if (section && typeof window.refreshSavedState === 'function') {
-    window.refreshSavedState(currentCorruptionSlot, section);
-  }
-
   // Trigger item display update
   triggerItemUpdate(currentCorruptionSlot);
+
+  // Refresh saved state AFTER triggerItemUpdate completes (so description and properties are in sync)
+  if (section && typeof window.refreshSavedState === 'function') {
+    setTimeout(() => window.refreshSavedState(currentCorruptionSlot, section), 150);
+  }
 
   closeCorruptionModal();
 }
@@ -1154,14 +1154,14 @@ function applyCorruptionToItem(corruptionText) {
     }
   }
 
-  // Refresh saved state to capture current corruption + ethereal + sockets
-  const section = SECTION_MAP[currentCorruptionSlot];
-  if (section && typeof window.refreshSavedState === 'function') {
-    window.refreshSavedState(currentCorruptionSlot, section);
-  }
-
   // Trigger item display update
   triggerItemUpdate(currentCorruptionSlot);
+
+  // Refresh saved state AFTER triggerItemUpdate completes (so description and properties are in sync)
+  const section = SECTION_MAP[currentCorruptionSlot];
+  if (section && typeof window.refreshSavedState === 'function') {
+    setTimeout(() => window.refreshSavedState(currentCorruptionSlot, section), 150);
+  }
 
   closeCorruptionModal();
 }

--- a/itemUpgrade.js
+++ b/itemUpgrade.js
@@ -4597,12 +4597,6 @@ function makeEtherealItem(category) {
     }
   }
 
-  // Refresh saved state to capture current ethereal status + sockets + corruption
-  const dropdownId = `${category}-dropdown`;
-  if (typeof window.refreshSavedState === 'function') {
-    window.refreshSavedState(dropdownId, category);
-  }
-
   // Reapply socket corruption if there was one
   if (socketCorruption) {
     const socketMatch = socketCorruption.match(/Socketed \((\d+)\)/);
@@ -4618,6 +4612,12 @@ function makeEtherealItem(category) {
   // Trigger change event to update display
   select.dispatchEvent(new Event("change"));
   if (window.unifiedSocketSystem?.updateAll) window.unifiedSocketSystem.updateAll();
+
+  // Refresh saved state AFTER updateAll() completes (so description and properties are in sync)
+  const dropdownId = `${category}-dropdown`;
+  if (typeof window.refreshSavedState === 'function') {
+    setTimeout(() => window.refreshSavedState(dropdownId, category), 100);
+  }
 }
 
 function makeEtherealWeapon(weaponName) {

--- a/socket.js
+++ b/socket.js
@@ -1655,13 +1655,13 @@
 
       this.updateAll();
 
-      // Refresh saved state after socket cleared
+      // Refresh saved state AFTER updateAll completes
       const container = socket.closest('.socket-container');
       const section = container?.dataset.section;
       if (section && typeof window.refreshSavedState === 'function') {
         const dropdownId = this.getSectionDropdownId(section);
         if (dropdownId) {
-          window.refreshSavedState(dropdownId, section);
+          setTimeout(() => window.refreshSavedState(dropdownId, section), 100);
         }
       }
     }
@@ -1695,17 +1695,16 @@
     }
     
     this.hideSocketModal();
+    this.currentSocket = null;
     this.updateAll();
 
-    // Refresh saved state after socket filled
+    // Refresh saved state AFTER updateAll completes
     if (section && typeof window.refreshSavedState === 'function') {
       const dropdownId = this.getSectionDropdownId(section);
       if (dropdownId) {
-        window.refreshSavedState(dropdownId, section);
+        setTimeout(() => window.refreshSavedState(dropdownId, section), 100);
       }
     }
-
-    this.currentSocket = null;
   }
     // === MODAL CREATION ===
     createSocketModal() {


### PR DESCRIPTION
…letes

ISSUE: Ethereal toggle only works if ethereal is last thing done to item
- Ethereal → corrupt → can't toggle ethereal anymore
- Ethereal → socket → can't toggle ethereal anymore

ROOT CAUSE: Description and properties out of sync when saving state
1. User modifies item (corrupt/socket/ethereal)
2. refreshSavedState() called immediately
3. Description hasn't regenerated yet (updateAll() not done)
4. properties.ethereal says one thing, description text says another
5. When trying to toggle, makeEtherealItem() checks BOTH and gets wrong state

makeEtherealItem() checks:
```
const isCurrentlyEthereal = properties.ethereal ||
  description.includes("Ethereal");
```

If they're out of sync, toggle goes wrong way.

SOLUTION: Call refreshSavedState() AFTER updateAll() completes

Changed in ALL modification points:
- itemUpgrade.js: setTimeout 100ms after updateAll()
- corrupt.js applyCorruptionToItem: setTimeout 150ms after triggerItemUpdate()
- corrupt.js applySocketCorruptionFromModal: setTimeout 150ms after triggerItemUpdate()
- socket.js fillSocket: setTimeout 100ms after updateAll()
- socket.js clearSocket: setTimeout 100ms after updateAll()

NOW: Description and properties are always in sync when state is saved Ethereal toggle works regardless of operation order.