### PR TITLE
Revert upgrade changes - they broke dropdowns

### DIFF
--- a/itemUpgrade.js
+++ b/itemUpgrade.js
@@ -44,33 +44,6 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 });
 
-// ===================================================================
-// HELPER FUNCTIONS for handling both regular and crafted items
-// ===================================================================
-
-/**
- * Safely update an item's data (works for both regular and crafted items)
- * @param {string} itemName - The item's name or fullName
- * @param {Object} newData - The new data to apply
- */
-function updateItemData(itemName, newData) {
-  // Check if it's a crafted item
-  const isCrafted = window.craftedItemsSystem?.isCraftedItem(itemName);
-
-  if (isCrafted) {
-    // Update crafted item in the crafted items system
-    const craftedItem = window.craftedItemsSystem.getCraftedItemByName(itemName);
-    if (craftedItem) {
-      // Update the crafted item's properties
-      Object.assign(craftedItem, newData);
-    }
-  } else {
-    // Update regular item in itemList
-    if (itemList[itemName]) {
-      itemList[itemName] = newData;
-    }
-  }
-}
 
 const upgradeDefinitions = {
   helms: {
@@ -3319,7 +3292,7 @@ function updateWeaponDescription() {
   if (!weaponSelect) return;
 
   const currentItem = weaponSelect.value;
-  const currentItemData = window.getItemData(currentItem);
+  const currentItemData = itemList[currentItem];
 
   if (currentItemData) {
     // Get description (generate if dynamic item)
@@ -3422,9 +3395,9 @@ function handleUpgrade() {
   const select = document.getElementById("helms-dropdown");
   const currentItem = select.value;
   const upgrades = upgradeDefinitions.helms[currentItem];
-  const currentItemData = window.getItemData(currentItem);
+  const currentItemData = itemList[currentItem];
 
-  if (!upgrades || !currentItemData) return;
+  if (!upgrades) return;
 
   const isDynamic = currentItemData.baseType && !currentItemData.description;
 
@@ -3463,11 +3436,11 @@ function handleUpgrade() {
 
       if (isDynamic) {
         // For dynamic items, update baseType and properties only (no description)
-        updateItemData(currentItem, {
+        itemList[currentItem] = {
           ...currentItemData,
           baseType: upgrades.elite.base,
           properties: { ...currentItemData.properties, ...newProperties },
-        });
+        };
 
         // Trigger update manually via socket system to ensure input boxes work
         if (window.unifiedSocketSystem && window.unifiedSocketSystem.equipmentMap) {
@@ -3478,7 +3451,7 @@ function handleUpgrade() {
         }
       } else {
         // For static items, build new description
-        updateItemData(currentItem, {
+        itemList[currentItem] = {
           description: buildDescription(
             currentItem,
             upgrades.elite.base,
@@ -3486,7 +3459,7 @@ function handleUpgrade() {
             magicalProperties
           ),
           properties: { ...currentItemData.properties, ...newProperties },
-        });
+        };
       }
 
       // For dynamic items, we already called updateItemDisplay above - skip dispatchEvent
@@ -3515,11 +3488,11 @@ function handleUpgrade() {
 
       if (isDynamic) {
         // For dynamic items, update baseType and properties only (no description)
-        updateItemData(currentItem, {
+        itemList[currentItem] = {
           ...currentItemData,
           baseType: upgrades.exceptional.base,
           properties: { ...currentItemData.properties, ...newProperties },
-        });
+        };
 
         // Trigger update manually via socket system to ensure input boxes work
         if (window.unifiedSocketSystem && window.unifiedSocketSystem.equipmentMap) {
@@ -3530,7 +3503,7 @@ function handleUpgrade() {
         }
       } else {
         // For static items, build new description
-        updateItemData(currentItem, {
+        itemList[currentItem] = {
           description: buildDescription(
             currentItem,
             upgrades.exceptional.base,
@@ -3538,7 +3511,7 @@ function handleUpgrade() {
             magicalProperties
           ),
           properties: { ...currentItemData.properties, ...newProperties },
-        });
+        };
       }
 
       // For dynamic items, we already called updateItemDisplay above - skip dispatchEvent
@@ -3560,7 +3533,7 @@ function handleArmorUpgrade() {
   const select = document.getElementById("armors-dropdown");
   const currentItem = select.value;
   const upgrades = upgradeDefinitions.armors[currentItem];
-  const currentItemData = window.getItemData(currentItem);
+  const currentItemData = itemList[currentItem];
 
   if (!upgrades) return;
 
@@ -3601,11 +3574,11 @@ function handleArmorUpgrade() {
 
       if (isDynamic) {
         // For dynamic items, update baseType and properties only (no description)
-        updateItemData(currentItem, {
+        itemList[currentItem] = {
           ...currentItemData,
           baseType: upgrades.elite.base,
           properties: { ...currentItemData.properties, ...newProperties },
-        });
+        };
 
         // Trigger update manually via socket system to ensure input boxes work
         if (window.unifiedSocketSystem && window.unifiedSocketSystem.equipmentMap) {
@@ -3616,7 +3589,7 @@ function handleArmorUpgrade() {
         }
       } else {
         // For static items, build new description
-        updateItemData(currentItem, {
+        itemList[currentItem] = {
           description: buildDescription(
             currentItem,
             upgrades.elite.base,
@@ -3624,7 +3597,7 @@ function handleArmorUpgrade() {
             magicalProperties
           ),
           properties: { ...currentItemData.properties, ...newProperties },
-        });
+        };
       }
 
       // For dynamic items, we already called updateItemDisplay above - skip dispatchEvent
@@ -3653,11 +3626,11 @@ function handleArmorUpgrade() {
 
       if (isDynamic) {
         // For dynamic items, update baseType and properties only (no description)
-        updateItemData(currentItem, {
+        itemList[currentItem] = {
           ...currentItemData,
           baseType: upgrades.exceptional.base,
           properties: { ...currentItemData.properties, ...newProperties },
-        });
+        };
 
         // Trigger update manually via socket system to ensure input boxes work
         if (window.unifiedSocketSystem && window.unifiedSocketSystem.equipmentMap) {
@@ -3668,7 +3641,7 @@ function handleArmorUpgrade() {
         }
       } else {
         // For static items, build new description
-        updateItemData(currentItem, {
+        itemList[currentItem] = {
           description: buildDescription(
             currentItem,
             upgrades.exceptional.base,
@@ -3676,7 +3649,7 @@ function handleArmorUpgrade() {
             magicalProperties
           ),
           properties: { ...currentItemData.properties, ...newProperties },
-        });
+        };
       }
 
       // For dynamic items, we already called updateItemDisplay above - skip dispatchEvent
@@ -3698,7 +3671,7 @@ function handleWeaponUpgrade() {
   const select = document.getElementById("weapons-dropdown");
   const currentItem = select.value;
   const upgrades = upgradeDefinitions.weapons[currentItem];
-  const currentItemData = window.getItemData(currentItem);
+  const currentItemData = itemList[currentItem];
 
   if (!upgrades) return;
 
@@ -3880,7 +3853,7 @@ function handleWeaponUpgradeWithCorruption() {
   const select = document.getElementById("weapons-dropdown");
   const currentItem = select.value;
   const upgrades = upgradeDefinitions.weapons[currentItem];
-  const currentItemData = window.getItemData(currentItem);
+  const currentItemData = itemList[currentItem];
 
   if (!upgrades) return;
 
@@ -4018,7 +3991,7 @@ function handleGloveUpgrade() {
   const select = document.getElementById("gloves-dropdown");
   const currentItem = select.value;
   const upgrades = upgradeDefinitions.gloves[currentItem];
-  const currentItemData = window.getItemData(currentItem);
+  const currentItemData = itemList[currentItem];
 
   if (!upgrades) return;
 
@@ -4063,11 +4036,11 @@ function handleGloveUpgrade() {
 
       if (isDynamic) {
         // For dynamic items, update baseType and properties only (no description)
-        updateItemData(currentItem, {
+        itemList[currentItem] = {
           ...currentItemData,
           baseType: upgrades.elite.base,
           properties: { ...currentItemData.properties, ...newProperties },
-        });
+        };
 
         // Trigger update manually via socket system to ensure input boxes work
         if (window.unifiedSocketSystem && window.unifiedSocketSystem.equipmentMap) {
@@ -4078,7 +4051,7 @@ function handleGloveUpgrade() {
         }
       } else {
         // For static items, build new description
-        updateItemData(currentItem, {
+        itemList[currentItem] = {
           description: buildDescription(
             currentItem,
             upgrades.elite.base,
@@ -4086,7 +4059,7 @@ function handleGloveUpgrade() {
             magicalProperties
           ),
           properties: { ...currentItemData.properties, ...newProperties },
-        });
+        };
       }
 
       // For dynamic items, we already called updateItemDisplay above - skip dispatchEvent
@@ -4116,11 +4089,11 @@ function handleGloveUpgrade() {
 
       if (isDynamic) {
         // For dynamic items, update baseType and properties only (no description)
-        updateItemData(currentItem, {
+        itemList[currentItem] = {
           ...currentItemData,
           baseType: upgrades.exceptional.base,
           properties: { ...currentItemData.properties, ...newProperties },
-        });
+        };
 
         // Trigger update manually via socket system to ensure input boxes work
         if (window.unifiedSocketSystem && window.unifiedSocketSystem.equipmentMap) {
@@ -4131,7 +4104,7 @@ function handleGloveUpgrade() {
         }
       } else {
         // For static items, build new description
-        updateItemData(currentItem, {
+        itemList[currentItem] = {
           description: buildDescription(
             currentItem,
             upgrades.exceptional.base,
@@ -4139,7 +4112,7 @@ function handleGloveUpgrade() {
             magicalProperties
           ),
           properties: { ...currentItemData.properties, ...newProperties },
-        });
+        };
       }
 
       // For dynamic items, we already called updateItemDisplay above - skip dispatchEvent
@@ -4161,7 +4134,7 @@ function handleBeltUpgrade() {
   const select = document.getElementById("belts-dropdown");
   const currentItem = select.value;
   const upgrades = upgradeDefinitions.belts[currentItem];
-  const currentItemData = window.getItemData(currentItem);
+  const currentItemData = itemList[currentItem];
 
   if (!upgrades) return;
 
@@ -4257,11 +4230,11 @@ function handleBeltUpgrade() {
 
       if (isDynamic) {
         // For dynamic items, update baseType and properties only (no description)
-        updateItemData(currentItem, {
+        itemList[currentItem] = {
           ...currentItemData,
           baseType: upgrades.exceptional.base,
           properties: { ...currentItemData.properties, ...newProperties },
-        });
+        };
 
         // Trigger update manually via socket system to ensure input boxes work
         if (window.unifiedSocketSystem && window.unifiedSocketSystem.equipmentMap) {
@@ -4272,7 +4245,7 @@ function handleBeltUpgrade() {
         }
       } else {
         // For static items, build new description
-        updateItemData(currentItem, {
+        itemList[currentItem] = {
           description: buildDescription(
             currentItem,
             upgrades.exceptional.base,
@@ -4280,7 +4253,7 @@ function handleBeltUpgrade() {
             magicalProperties
           ),
           properties: { ...currentItemData.properties, ...newProperties },
-        });
+        };
       }
 
       // For dynamic items, we already called updateItemDisplay above - skip dispatchEvent
@@ -4380,7 +4353,7 @@ document.addEventListener("DOMContentLoaded", () => {
 function makeEthereal() {
   const select = document.getElementById("helms-dropdown");
   const currentItem = select.value;
-  const currentItemData = window.getItemData(currentItem);
+  const currentItemData = itemList[currentItem];
 
   const isCurrentlyEthereal = currentItemData.properties?.ethereal ||
     (currentItemData.description && currentItemData.description.includes("Ethereal"));
@@ -4404,7 +4377,7 @@ function makeEthereal() {
 function makeEtherealArmor() {
   const select = document.getElementById("armors-dropdown");
   const currentItem = select.value;
-  const currentItemData = window.getItemData(currentItem);
+  const currentItemData = itemList[currentItem];
 
   const isCurrentlyEthereal = currentItemData.properties?.ethereal ||
     (currentItemData.description && currentItemData.description.includes("Ethereal"));
@@ -4428,7 +4401,7 @@ function makeEtherealArmor() {
 function makeEtherealItem(category) {
   const select = document.getElementById(`${category}-dropdown`);
   const currentItem = select.value;
-  const currentItemData = window.getItemData(currentItem);
+  const currentItemData = itemList[currentItem];
 
   if (!currentItemData) return;
 
@@ -4709,7 +4682,7 @@ function updateWeaponDamageDisplay() {
   if (!weaponSelect) return;
 
   const currentItem = weaponSelect.value;
-  const currentItemData = window.getItemData(currentItem);
+  const currentItemData = itemList[currentItem];
 
   if (currentItemData) {
     const isDynamic = currentItemData.baseType;
@@ -4944,7 +4917,7 @@ function updateWeaponDescription() {
   if (!weaponSelect) return;
 
   const currentItem = weaponSelect.value;
-  const currentItemData = window.getItemData(currentItem);
+  const currentItemData = itemList[currentItem];
 
   if (currentItemData) {
     // Get description (generate if dynamic item)
@@ -5527,7 +5500,7 @@ function updateWeaponDisplayWithPerLevelDamage() {
 function makeEtherealShield() {
   const select = document.getElementById("offs-dropdown");
   const currentItem = select.value;
-  const currentItemData = window.getItemData(currentItem);
+  const currentItemData = itemList[currentItem];
 
   if (!currentItemData) return;
 


### PR DESCRIPTION
The upgrade fix was too risky and broke all dropdowns. Reverting to keep the other working fixes (variable stats and merge for crafted items).