### PR TITLE
Fix corruption +to All Skills not appearing in stats counter

### DIFF
--- a/corrupt.js
+++ b/corrupt.js
@@ -1048,6 +1048,10 @@ function applyCorruptionToProperties(itemName, corruptionText) {
           props.edef = (props.edef || 0) + stat.value;
         }
         break;
+      case 'allskills':
+        // +X to All Skills
+        props.allskills = (props.allskills || 0) + stat.value;
+        break;
     }
   });
 }


### PR DESCRIPTION
Add missing 'allskills' case in applyCorruptionToProperties function. Previously, +X to All Skills corruption would display in the item description but not update the item properties, causing the stats counter to not recognize it.