### PR TITLE
Fix corruption allskills property name

### DIFF
--- a/corrupt.js
+++ b/corrupt.js
@@ -1050,7 +1050,7 @@ function applyCorruptionToProperties(itemName, corruptionText) {
         break;
       case 'allskills':
         // +X to All Skills
-        props.allskills = (props.allskills || 0) + stat.value;
+        props.allsk = (props.allsk || 0) + stat.value;
         break;
     }
   });


### PR DESCRIPTION
Change from 'allskills' to 'allsk' to match the expected property name in generateItemDescription. This ensures the corruption bonus displays correctly with the '+' sign and stacks properly.