### PR TITLE
Fix corruption stat stacking losing the + sign

### DIFF
--- a/corrupt.js
+++ b/corrupt.js
@@ -1362,9 +1362,11 @@ function replaceExistingStatWithCorruption(description, corruptionStat) {
     const originalValue = parseInt(match[1]);
     const newValue = originalValue + corruptionStat.value;
 
-    // Replace the old value with new value
-    // The sign is already in the pattern, so we just replace the number
-    const newStatText = match[0].replace(match[1], newValue.toString());
+    // Replace the old value with new value, preserving the + sign
+    // The pattern captures the optional + sign with the number, so we need to add it back
+    const hasPlus = match[1].startsWith('+');
+    const newValueStr = hasPlus ? '+' + newValue.toString() : newValue.toString();
+    const newStatText = match[0].replace(match[1], newValueStr);
     const redStatText = `<span class="corruption-enhanced-stat">${newStatText}</span>`;
 
     const newDescription = description.replace(match[0], redStatText);


### PR DESCRIPTION
When corruption stacks with existing stats, preserve the + sign. The regex pattern captures (+?\d+) which includes the optional +, but when replacing the value we were only putting back the number. Now we check if the original had a + and preserve it.