### PR TITLE
Fix allsk corruption being counted twice for dynamic items

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -2533,14 +2533,10 @@ this.selectedJewelSuffix3MaxValue = null;
       // (This is critical for items like Arcanna's Deathwand with variable stats)
       let baseDescription = window.generateItemDescription(dropdown.value, item, dropdownId);
 
-      // Check if item has corruption applied
-      if (window.itemCorruptions && window.itemCorruptions[dropdownId]) {
-        const corruption = window.itemCorruptions[dropdownId];
-        if (corruption.text && typeof window.addCorruptionWithStacking === 'function') {
-          // Apply corruption to the dynamically generated description
-          baseDescription = window.addCorruptionWithStacking(baseDescription, corruption.text);
-        }
-      }
+      // NOTE: For dynamic items, corruption has already been applied to properties
+      // by applyCorruptionToProperties in corrupt.js, so the generated description
+      // already includes the corrupted values. We should NOT call addCorruptionWithStacking
+      // again as that would double-count the corruption stats.
 
       // Parse base stats from the generated description (strip input elements first)
       const tempDiv = document.createElement('div');


### PR DESCRIPTION
The issue was in updateItemDisplay for dynamic items:
1. applyCorruptionToProperties already modifies item.properties.allsk
2. generateItemDescription reads the corrupted properties (allsk=2)
3. Then addCorruptionWithStacking was called AGAIN with the original corruption text, stacking it a second time (2+1=3)

For dynamic items, the corruption is already baked into the properties, so we should NOT call addCorruptionWithStacking again when regenerating the description.

This fixes the "+3 to All Skills" bug when it should show "+2 to All Skills"