### PR TITLE
Fix input boxes breaking for corrupted dynamic items

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -2529,41 +2529,17 @@ this.selectedJewelSuffix3MaxValue = null;
 
     // Handle dynamic items (no static description)
     if (!item.description) {
-      // For dynamic items with corruption, we need to:
-      // 1. Generate description from ORIGINAL (uncorrupted) properties
-      // 2. Apply corruption with addCorruptionWithStacking (adds red styling and stacking)
-      // This prevents double-counting corruption stats while maintaining proper display
+      // For dynamic items, always generate from current properties
+      // (corruption has already been applied to properties by applyCorruptionToProperties)
+      let baseDescription = window.generateItemDescription(dropdown.value, item, dropdownId);
 
-      let baseDescription;
+      // Add corruption text in red (simple append - no stacking logic that breaks input boxes)
       const itemName = dropdown.value;
-
-      // Check if item has corruption
       if (window.itemCorruptions && window.itemCorruptions[dropdownId]) {
         const corruption = window.itemCorruptions[dropdownId];
-
-        // Use stored original description if available
-        if (window.originalItemDescriptions && window.originalItemDescriptions[itemName]) {
-          baseDescription = window.originalItemDescriptions[itemName];
-        } else {
-          // Fallback: Generate from original properties if available
-          if (window.originalItemProperties && window.originalItemProperties[itemName]) {
-            const currentProps = item.properties;
-            item.properties = JSON.parse(JSON.stringify(window.originalItemProperties[itemName]));
-            baseDescription = window.generateItemDescription(itemName, item, dropdownId);
-            item.properties = currentProps;
-          } else {
-            // Last resort: Generate with current properties
-            baseDescription = window.generateItemDescription(itemName, item, dropdownId);
-          }
+        if (corruption.text) {
+          baseDescription += `<span class="corruption-enhanced-stat">${corruption.text}</span><br>`;
         }
-
-        // Apply corruption with stacking (adds red styling)
-        if (corruption.text && typeof window.addCorruptionWithStacking === 'function') {
-          baseDescription = window.addCorruptionWithStacking(baseDescription, corruption.text);
-        }
-      } else {
-        // No corruption - generate normally
-        baseDescription = window.generateItemDescription(itemName, item, dropdownId);
       }
 
       // Parse base stats from the generated description (strip input elements first)


### PR DESCRIPTION
The previous approach used addCorruptionWithStacking which:
1. Mangled HTML structure, breaking input box elements
2. Prevented event listeners from reattaching properly

New simpler approach for dynamic items:
1. Generate description from current (corrupted) properties
   - Shows correct values in input boxes
   - applyCorruptionToProperties already updated the properties
2. Simply append corruption text in red (no complex stacking)
   - Preserves HTML structure
   - Maintains input box functionality

This fixes the critical issue where users couldn't adjust variable stats after corrupting a dynamic item.